### PR TITLE
Add support for remove node

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -90,7 +90,7 @@ parts:
     after:
       - dqlite
     plugin: go
-    source: https://github.com/hemanthnakkina/sunbeam-microcluster
+    source: https://github.com/openstack-snaps/sunbeam-microcluster
     source-depth: 1
     source-type: git
     build-snaps:

--- a/sunbeam/clusterd/cluster.py
+++ b/sunbeam/clusterd/cluster.py
@@ -14,29 +14,49 @@
 # limitations under the License.
 
 import json
+import logging
 
 from sunbeam.clusterd import service
 
+LOG = logging.getLogger(__name__)
 
-class ClusterService(service.BaseService):
-    """Lists and manages cluster."""
 
-    def bootstrap(self, name: str, address: str) -> None:
+class MicroClusterService(service.BaseService):
+    """Client for default MicroCluster Service API."""
+
+    def bootstrap_cluster(self, name: str, address: str) -> None:
+        """Bootstrap the micro cluster.
+
+        Boostraps the cluster adding local node specified by
+        name as bootstrap node. The address should be in
+        format <IP>:<PORT> where the microcluster service
+        is running.
+
+        Raises NodeAlreadyExistsException if bootstrap is
+        invoked on already existing node in cluster.
+        """
         data = {"bootstrap": True, "address": address, "name": name}
         self._post("cluster/control", data=json.dumps(data))
 
-    def add_node(self, name: str) -> str:
-        data = {"name": name}
-        result = self._post("/cluster/1.0/tokens", data=json.dumps(data))
-        return result.get("metadata")
+    def join(self, name: str, address: str, token: str) -> None:
+        """Join node to the micro cluster.
 
-    def join_node(self, name: str, address: str, token: str, role: str) -> None:
+        Verified the token with the list of saved tokens and
+        joins the node with the given name and address.
+
+        Raises NodeAlreadyExistsException if the node is already
+        part of the cluster.
+        Raises NodeJoinException if the token doesnot match or not
+        part of the generated tokens list.
+        """
         data = {"join_token": token, "address": address, "name": name}
         self._post("cluster/control", data=json.dumps(data))
-        data = {"name": name, "role": role}
-        self._post("/1.0/nodes", data=json.dumps(data))
 
-    def get_cluster_members(self):
+    def get_cluster_members(self) -> list:
+        """List members in the cluster.
+
+        Returns a list of all members in the cluster.
+        """
         result = []
         cluster = self._get("/cluster/1.0/cluster")
         members = cluster.get("metadata", {})
@@ -44,3 +64,77 @@ class ClusterService(service.BaseService):
         for member in members:
             result.append({k: v for k, v in member.items() if k in keys})
         return result
+
+    def remove(self, name: str) -> None:
+        """Remove node from the cluster.
+
+        Raises NodeNotExistInClusterException if node does not
+        exist in the cluster.
+        Raises NodeRemoveFromClusterException if the node is last
+        member of the cluster.
+        """
+        self._delete(f"/cluster/1.0/cluster/{name}")
+
+    def generate_token(self, name: str) -> str:
+        """Generate token for the node.
+
+        Generate a new token for the node with name.
+
+        Raises TokenAlreadyGeneratedException if token is already
+        generated.
+        """
+        data = {"name": name}
+        result = self._post("/cluster/1.0/tokens", data=json.dumps(data))
+        return result.get("metadata")
+
+    def list_tokens(self) -> list:
+        """List all generated tokens."""
+        tokens = self._get("/cluster/1.0/tokens")
+        return tokens.get("metadata")
+
+    def delete_token(self, name: str) -> None:
+        """Delete token for the node.
+
+        Raises TokenNotFoundException if token does not exist.
+        """
+        self._delete(f"/cluster/internal/tokens/{name}")
+
+
+class ExtendedAPIService(service.BaseService):
+    """Client for Sunbeam extended Cluster API."""
+
+    def add_node_info(self, name: str, role: str) -> None:
+        """Add Node information to cluster database."""
+        data = {"name": name, "role": role}
+        self._post("/1.0/nodes", data=json.dumps(data))
+
+    def remove_node_info(self, name: str) -> None:
+        """Remove Node information from cluster database."""
+        self._delete(f"1.0/nodes/{name}")
+
+
+class ClusterService(MicroClusterService, ExtendedAPIService):
+    """Lists and manages cluster."""
+
+    def bootstrap(self, name: str, address: str, role: str) -> None:
+        self.bootstrap_cluster(name, address)
+        self.add_node_info(name, role)
+
+    def add_node(self, name: str) -> str:
+        return self.generate_token(name)
+
+    def join_node(self, name: str, address: str, token: str, role: str) -> None:
+        self.join(name, address, token)
+        self.add_node_info(name, role)
+
+    def remove_node(self, name) -> None:
+        members = self.get_cluster_members()
+        member_names = [member.get("name") for member in members]
+
+        # If node is part of cluster, remove node from cluster
+        if name in member_names:
+            self.remove_node_info(name)
+            self.remove(name)
+        else:
+            # Check if token exists in token list and remove
+            self.delete_token(name)

--- a/sunbeam/commands/bootstrap.py
+++ b/sunbeam/commands/bootstrap.py
@@ -45,7 +45,7 @@ def bootstrap(role: str) -> None:
     LOG.debug(f"Bootstrap node: role {role}")
 
     plan = []
-    plan.append(ClusterInitStep())
+    plan.append(ClusterInitStep(role.upper()))
 
     for step in plan:
         LOG.debug(f"Starting step {step.name}")

--- a/sunbeam/commands/node.py
+++ b/sunbeam/commands/node.py
@@ -22,6 +22,7 @@ from sunbeam.commands.clusterd import (
     ClusterAddNodeStep,
     ClusterJoinNodeStep,
     ClusterListNodeStep,
+    ClusterRemoveNodeStep,
 )
 from sunbeam.jobs.common import ResultType
 
@@ -120,3 +121,35 @@ def list() -> None:
         console.print(f"{message}[green]done[/green]")
         click.echo("Sunbeam Cluster Node List:")
         click.echo(f"{result.message}")
+
+
+@click.command()
+@click.option("--name", type=str, prompt=True, help="Fully qualified node name")
+def remove(name: str) -> None:
+    """Remove node from the cluster.
+
+    Remove a node from the cluster.
+    If the node does not exist, it removes the node
+    from the token records.
+    """
+    step = ClusterRemoveNodeStep(name)
+
+    LOG.debug(f"Starting step {step.name}")
+    message = f"{step.description} ... "
+    if step.is_skip():
+        LOG.debug(f"Skipping step {step.name}")
+        console.print(f"{message}[green]done[/green]")
+        click.echo("Node not part of the sunbeam cluster")
+    else:
+        LOG.debug(f"Running step {step.name}")
+        result = step.run()
+        LOG.debug(
+            f"Finished running step {step.name}. " f"Result: {result.result_type}"
+        )
+
+        if result.result_type == ResultType.FAILED:
+            console.print(f"{message}[red]failed[/red]")
+            raise click.ClickException(result.message)
+
+        console.print(f"{message}[green]done[/green]")
+        click.echo(f"Removed Node {name} from the cluster")

--- a/sunbeam/main.py
+++ b/sunbeam/main.py
@@ -54,6 +54,7 @@ def main():
     cluster.add_command(node_cmds.add_node)
     cluster.add_command(node_cmds.join)
     cluster.add_command(node_cmds.list)
+    cluster.add_command(node_cmds.remove)
     cli()
 
 


### PR DESCRIPTION
Add openstack.sunbeam cluster remove command.
Reorganise cluster service client functions to the microcluster exposed API and extended API.
Point sunbeam-microcluster in snapcraft.yaml to
openstack-snaps/sunbeam-microcluster.

Depends-On: https://github.com/openstack-snaps/sunbeam-microcluster/pull/2