### PR TITLE
Add config store APIs into sunbeam

### DIFF
--- a/sunbeam/clusterd/cluster.py
+++ b/sunbeam/clusterd/cluster.py
@@ -15,6 +15,7 @@
 
 import json
 import logging
+from typing import Any
 
 from sunbeam.clusterd import service
 
@@ -139,6 +140,18 @@ class ExtendedAPIService(service.BaseService):
     def remove_juju_user(self, name: str) -> None:
         """Remove Juju user from cluster database."""
         self._delete(f"1.0/jujuusers/{name}")
+
+    def get_config(self, key: str) -> Any:
+        """Fetch configuration from database."""
+        return self._get(f"/1.0/config/{key}").get("metadata")
+
+    def update_config(self, key: str, value: Any):
+        """Update configuration in database, create if missing."""
+        self._put(f"/1.0/config/{key}", data=json.dumps(value))
+
+    def delete_config(self, key: str):
+        """Remove configuration from database."""
+        self._delete(f"/1.0/config/{key}")
 
 
 class ClusterService(MicroClusterService, ExtendedAPIService):

--- a/sunbeam/clusterd/service.py
+++ b/sunbeam/clusterd/service.py
@@ -43,6 +43,12 @@ class ClusterServiceUnavailableException(RemoteException):
     pass
 
 
+class ConfigItemNotFoundException(RemoteException):
+    """Raise when ConfigItem cannot be found on the remote"""
+
+    pass
+
+
 class NodeAlreadyExistsException(RemoteException):
     """Raised when the node already exists"""
 
@@ -148,6 +154,8 @@ class BaseService(ABC):
                 raise ClusterAlreadyBootstrappedException(
                     "Already cluster is bootstrapped."
                 )
+            elif "ConfigItem not found" in error:
+                raise ConfigItemNotFoundException("ConfigItem not found")
             raise e
 
         return response.json()


### PR DESCRIPTION
Configuration endpoints allow to store, retrieve and delete configuration from the database.

Depends-On: https://github.com/openstack-snaps/sunbeam-microcluster/pull/6