### PR TITLE
plugs: setup usage of dot-kube

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -32,6 +32,7 @@ apps:
     command: bin/sunbeam
     plugs:
       - dot-local-share-juju
+      - dot-kube
       - home
       - network
       - network-bind
@@ -169,3 +170,8 @@ plugs:
     interface: personal-files
     write:
       - $HOME/.local/share/juju
+
+  dot-kube:
+    interface: personal-files
+    read:
+      - $HOME/.kube


### PR DESCRIPTION
This was required for microstack for Juju + K8S interaction so adding the same to this snap for compatibility.