### PR TITLE
Use http backend for terraform

### DIFF
--- a/cloud/etc/deploy-microk8s/main.tf
+++ b/cloud/etc/deploy-microk8s/main.tf
@@ -14,11 +14,16 @@
 # limitations under the License.
 
 terraform {
+
   required_providers {
     juju = {
       source  = "juju/juju"
       version = ">= 0.6.0"
     }
+  }
+
+  backend "http" {
+    skip_cert_verification = true
   }
 }
 

--- a/sunbeam/commands/bootstrap.py
+++ b/sunbeam/commands/bootstrap.py
@@ -94,7 +94,10 @@ def bootstrap(role: str) -> None:
     plan.append(ClusterInitStep(role.upper()))
 
     tfhelper = TerraformHelper(
-        path=snap.paths.user_common / "etc" / "deploy-microk8s", parallelism=1
+        path=snap.paths.user_common / "etc" / "deploy-microk8s",
+        plan="microk8s-plan",
+        parallelism=1,
+        backend="http",
     )
 
     if node_role.is_control_node():


### PR DESCRIPTION
Use http terraform for terraform plan.
Update the necessary environment variables for using http backend.

Depends-On: https://github.com/openstack-snaps/sunbeam-microcluster/pull/12