### PR TITLE
Add daemon.group configuration to change socket's ownership

### DIFF
--- a/snap-wrappers/commands/clusterd.start
+++ b/snap-wrappers/commands/clusterd.start
@@ -1,4 +1,5 @@
 #!/bin/sh
 export DQLITE_SOCKET="@snap.${SNAP_INSTANCE_NAME}.dqlite"
+export SOCKET_GROUP="$(snapctl get 'daemon.group')"
 
-exec sunbeamd --state-dir "${SNAP_COMMON}/state"
+exec sunbeamd --state-dir "${SNAP_COMMON}/state" --socket-group "${SOCKET_GROUP}"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -12,7 +12,6 @@ grade: devel
 architectures:
   - build-on: amd64
 
-
 system-usernames:
   snap_daemon: shared
 

--- a/sunbeam/hooks.py
+++ b/sunbeam/hooks.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import logging
 
 from snaphelpers import Snap
@@ -21,6 +22,7 @@ LOG = logging.getLogger(__name__)
 DEFAULT_CONFIG = {
     "juju.cloud.type": "manual",
     "juju.cloud.name": "sunbeam",
+    "daemon.group": "snap_daemon",
 }
 
 
@@ -73,7 +75,7 @@ def configure(snap: Snap) -> None:
 
     This method is invoked when the configure hook is executed by the snapd
     daemon. The `configure` hook is invoked when the user runs a sudo snap
-    set openstack-hypervisor.<foo> setting.
+    set openstack.<foo> setting.
 
     :param snap: the snap reference
     :type snap: Snap


### PR DESCRIPTION
Add `daemon.group` option and pass it to sunbeamd to set socket's group ownership to this group.

Using `snap_daemon` as group while waiting to get our `snap_openstack` group.

Depends-On: 
- [ ] https://github.com/openstack-snaps/sunbeam-microcluster/pull/14