### PR TITLE
Add ssh-init command

### DIFF
--- a/sunbeam/commands/ssh_init.py
+++ b/sunbeam/commands/ssh_init.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2023 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import click
+from rich.console import Console
+
+console = Console()
+
+
+SSH_INIT_TEMPLATE = """ssh-keygen -b 4096 -f $HOME/.ssh/id_rsa -t rsa -N ""
+cat $HOME/.ssh/id_rsa.pub >> $HOME/.ssh/authorized_keys
+ssh-keyscan -H $(hostname --all-ip-addresses) >> $HOME/.ssh/known_hosts
+"""
+
+
+@click.command()
+def ssh_init() -> None:
+    """Generate ssh init script"""
+    console.print(SSH_INIT_TEMPLATE)

--- a/sunbeam/main.py
+++ b/sunbeam/main.py
@@ -19,6 +19,7 @@ import click
 
 from sunbeam import log
 from sunbeam.commands import bootstrap as bootstrap_cmds
+from sunbeam.commands import ssh_init as ssh_init_cmds
 from sunbeam.commands import node as node_cmds
 
 LOG = logging.getLogger()
@@ -55,6 +56,7 @@ def main():
     cluster.add_command(node_cmds.join)
     cluster.add_command(node_cmds.list)
     cluster.add_command(node_cmds.remove)
+    cluster.add_command(ssh_init_cmds.ssh_init)
     cli()
 
 


### PR DESCRIPTION
Init command outputs commands to pipe to bash to set up the ssh keys allowed to be used with manual provider.