### PR TITLE
Disable colors from terraform output

### DIFF
--- a/sunbeam/commands/terraform.py
+++ b/sunbeam/commands/terraform.py
@@ -123,7 +123,7 @@ class TerraformHelper:
             os_env.update(self.update_juju_provider_credentials())
 
         try:
-            cmd = [self.terraform, "init"]
+            cmd = [self.terraform, "init", "-no-color"]
             LOG.debug(f'Running command {" ".join(cmd)}')
             process = subprocess.run(
                 cmd,
@@ -155,7 +155,7 @@ class TerraformHelper:
             os_env.update(self.update_juju_provider_credentials())
 
         try:
-            cmd = [self.terraform, "apply", "-auto-approve"]
+            cmd = [self.terraform, "apply", "-auto-approve", "-no-color"]
             if self.parallelism is not None:
                 cmd.append(f"-parallelism={self.parallelism}")
             LOG.debug(f'Running command {" ".join(cmd)}')


### PR DESCRIPTION
Terraform coloring is not interpreted by Rich when output, showing ascii code, making reading tf output hard. Use `-no-color` option on tf commands to simplify output

Rich keeps highlighting the TF Output, keeping it colored on patterns it recognizes.

# Before:
![image](https://user-images.githubusercontent.com/4944914/229832346-d47db7e3-6847-4758-99bd-1afee7d002a8.png)

# After:
![image](https://user-images.githubusercontent.com/4944914/229832473-ae3f3a16-3615-4cda-a83c-920fe5892c47.png)
