### PR TITLE
Add checks for ssh-keys interface presence

### DIFF
--- a/sunbeam/commands/node.py
+++ b/sunbeam/commands/node.py
@@ -37,11 +37,13 @@ from sunbeam.commands.juju import (
     # RemoveJujuUserStep,
 )
 from sunbeam.commands.microk8s import AddMicrok8sUnitStep, RemoveMicrok8sUnitStep
+from sunbeam.jobs.checks import JujuSnapCheck, SshKeysConnectedCheck
 from sunbeam.jobs.common import (
     Role,
     get_step_message,
     run_plan,
     ResultType,
+    run_preflight_checks,
 )
 from sunbeam.jobs.juju import CONTROLLER, JujuHelper
 
@@ -93,6 +95,12 @@ def join(token: str, role: str) -> None:
     # Register juju user with same name as Node fqdn
     name = utils.get_fqdn()
     ip = utils.get_local_ip_by_default_route()
+
+    preflight_checks = []
+    preflight_checks.append(JujuSnapCheck())
+    preflight_checks.append(SshKeysConnectedCheck())
+
+    run_preflight_checks(preflight_checks, console)
 
     controller = CONTROLLER
     data_location = snap.paths.user_data

--- a/sunbeam/jobs/checks.py
+++ b/sunbeam/jobs/checks.py
@@ -15,7 +15,7 @@
 
 import logging
 
-from snaphelpers import Snap
+from snaphelpers import Snap, SnapCtl
 
 LOG = logging.getLogger(__name__)
 
@@ -65,4 +65,29 @@ class JujuSnapCheck(Check):
 
             return False
 
+        return True
+
+
+class SshKeysConnectedCheck(Check):
+    """Check if ssh-keys interface is connected or not."""
+
+    def __init__(self):
+        super().__init__(
+            "Check for ssh-keys interface",
+            "Checking for presence of ssh-keys interface",
+        )
+
+    def run(self) -> bool:
+        """Check for ssh-keys interface."""
+
+        snap = Snap()
+        snap_ctl = SnapCtl()
+        connect = f"sudo snap connect {snap.name}:ssh-keys"
+
+        if not snap_ctl.is_connected("ssh-keys"):
+            self.message = (
+                "ssh-keys interface not detected: please connect ssh-keys interface "
+                f"by running {connect!r}"
+            )
+            return False
         return True

--- a/sunbeam/jobs/common.py
+++ b/sunbeam/jobs/common.py
@@ -178,6 +178,26 @@ class BaseStep:
         pass
 
 
+def run_preflight_checks(checks: list, console: Console):
+    """Run preflight checks sequentially.
+
+    Runs each checks, logs whether the check passed or failed.
+    Exits at first failure.
+
+    Raise ClickException in case of Result Failures.
+    """
+    for check in checks:
+        LOG.debug(f"Starting pre-flight check {check.name}")
+        message = f"{check.description} ... "
+        with console.status(message):
+            if check.run():
+                console.print(f"{message}[green]done[/green]")
+            else:
+                console.print(f"{message}[red]failed[/red]")
+                console.print()
+                raise click.ClickException(check.message)
+
+
 def run_plan(plan: list, console: Console) -> dict:
     """Run plans sequentially.
 

--- a/tests/unit/sunbeam/jobs/test_checks.py
+++ b/tests/unit/sunbeam/jobs/test_checks.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2023 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import Mock
+
+from sunbeam.jobs import checks
+
+
+class TestSshKeysConnectedCheck:
+    def test_run(self, mocker, snap):
+        snap_ctl = Mock()
+        mocker.patch.object(checks, "Snap", return_value=snap)
+        mocker.patch.object(checks, "SnapCtl", return_value=snap_ctl)
+
+        check = checks.SshKeysConnectedCheck()
+
+        result = check.run()
+
+        assert result is True
+
+    def test_run_missing_interface(self, mocker, snap):
+        snap_ctl = Mock(is_connected=Mock(return_value=False))
+        mocker.patch.object(checks, "Snap", return_value=snap)
+        mocker.patch.object(checks, "SnapCtl", return_value=snap_ctl)
+
+        check = checks.SshKeysConnectedCheck()
+
+        result = check.run()
+
+        assert result is False
+        assert "sudo snap connect mysnap:ssh-keys" in check.message


### PR DESCRIPTION
To be able to setup the machines with the manual providers, we need access to the user's ssh keys. Therefore, we need the user to grant access to the snap.