### PR TITLE
Catch exceptions for wait_until_active

### DIFF
--- a/sunbeam/commands/openstack.py
+++ b/sunbeam/commands/openstack.py
@@ -26,7 +26,7 @@ from sunbeam.commands.microk8s import (
 )
 from sunbeam.commands.terraform import TerraformException, TerraformHelper
 from sunbeam.jobs.common import BaseStep, Result, ResultType
-from sunbeam.jobs.juju import JujuHelper, TimeoutException, run_sync
+from sunbeam.jobs.juju import JujuHelper, JujuWaitException, TimeoutException, run_sync
 
 LOG = logging.getLogger(__name__)
 OPENSTACK_MODEL = "openstack"
@@ -81,6 +81,9 @@ class DeployControlPlaneStep(BaseStep, JujuStepHelper):
                     timeout=OPENSTACK_DEPLOY_TIMEOUT,
                 )
             )
+        except JujuWaitException as e:
+            LOG.warning(str(e))
+            return Result(ResultType.FAILED, str(e))
         except TimeoutException as e:
             LOG.warning(str(e))
             return Result(ResultType.FAILED, str(e))

--- a/tests/unit/sunbeam/jobs/test_juju.py
+++ b/tests/unit/sunbeam/jobs/test_juju.py
@@ -431,3 +431,29 @@ async def test_jhelper_wait_ready_missing_application(
 async def test_jhelper_wait_until_active(jhelper: juju.JujuHelper, model):
     await jhelper.wait_until_active("control-plane")
     assert model.wait_for_idle.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_jhelper_wait_until_active_unit_in_error_state(
+    jhelper: juju.JujuHelper, model
+):
+    model.wait_for_idle.side_effect = juju.JujuWaitException("Unit is in error state")
+
+    with pytest.raises(
+        juju.JujuWaitException,
+        match="Unit is in error state",
+    ):
+        await jhelper.wait_until_active("control-plane")
+    assert model.wait_for_idle.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_jhelper_wait_until_active_timed_out(jhelper: juju.JujuHelper, model):
+    model.wait_for_idle.side_effect = juju.TimeoutException("timed out...")
+
+    with pytest.raises(
+        juju.TimeoutException,
+        match="timed out...",
+    ):
+        await jhelper.wait_until_active("control-plane")
+    assert model.wait_for_idle.call_count == 1


### PR DESCRIPTION
Wait_until_active can raise JujuUnitError, JujuMachineError,
JujuAppError, JujuAgentError. Catch these exceptions
and pass the message to the user.