### PR TITLE
ux: silence missing controller warning

### DIFF
--- a/sunbeam/commands/juju.py
+++ b/sunbeam/commands/juju.py
@@ -131,7 +131,7 @@ class JujuStepHelper:
         try:
             return self._juju_cmd("show-controller", controller)[controller]
         except subprocess.CalledProcessError as e:
-            LOG.warning(e)
+            LOG.debug(e)
             raise ControllerNotFoundException() from e
 
     def add_cloud(self, cloud_type: str, cloud_name: str) -> bool:


### PR DESCRIPTION
Its possible that a controller won't exist during certain points in the bootstrap process; this is not a problem so just log the message at debug level rather than as a warning.