### PR TITLE
Add configure step

### DIFF
--- a/cloud/etc/demo-setup/README.md
+++ b/cloud/etc/demo-setup/README.md
@@ -1,0 +1,4 @@
+# Terraform configuration for default flavors, images etc
+
+This directory contains a parameterized Terraform configuration
+to setup default resources in OpenStack

--- a/cloud/etc/demo-setup/main.tf
+++ b/cloud/etc/demo-setup/main.tf
@@ -1,0 +1,186 @@
+terraform {
+  required_version = ">= 0.14.0"
+  required_providers {
+    openstack = {
+      source  = "terraform-provider-openstack/openstack"
+      version = "~> 1.48.0"
+    }
+  }
+}
+
+provider "openstack" {}
+
+# Flavors
+resource "openstack_compute_flavor_v2" "m1_tiny" {
+  name      = "m1.tiny"
+  ram       = "512"
+  vcpus     = "1"
+  disk      = "4"
+  is_public = true
+}
+
+resource "openstack_compute_flavor_v2" "m1_small" {
+  name      = "m1.small"
+  ram       = "2048"
+  vcpus     = "1"
+  disk      = "30"
+  is_public = true
+}
+
+resource "openstack_compute_flavor_v2" "m1_medium" {
+  name      = "m1.medium"
+  ram       = "4096"
+  vcpus     = "2"
+  disk      = "60"
+  is_public = true
+}
+
+resource "openstack_compute_flavor_v2" "m1_large" {
+  name      = "m1.large"
+  ram       = "8192"
+  vcpus     = "4"
+  disk      = "90"
+  is_public = true
+}
+
+resource "openstack_images_image_v2" "ubuntu_jammy" {
+  name             = "ubuntu-jammy"
+  image_source_url = "http://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img"
+  container_format = "bare"
+  disk_format      = "qcow2"
+  visibility       = "public"
+}
+
+# External networking
+resource "openstack_networking_network_v2" "external_network" {
+  name           = "external-network"
+  admin_state_up = true
+  external       = true
+  segments {
+    physical_network = var.external_network.physical_network
+    network_type     = var.external_network.network_type
+    segmentation_id  = var.external_network.segmentation_id
+  }
+}
+
+resource "openstack_networking_subnet_v2" "external_subnet" {
+  name        = "external-subnet"
+  network_id  = openstack_networking_network_v2.external_network.id
+  cidr        = var.external_network.cidr
+  ip_version  = 4
+  enable_dhcp = false
+  allocation_pool {
+    start = var.external_network.start
+    end   = var.external_network.end
+  }
+  gateway_ip = var.external_network.gateway
+}
+
+# User configuration
+resource "openstack_identity_project_v3" "users_domain" {
+  name      = "users"
+  is_domain = true
+}
+
+resource "openstack_identity_project_v3" "user_project" {
+  name      = var.user.username
+  domain_id = openstack_identity_project_v3.users_domain.id
+}
+
+resource "openstack_identity_user_v3" "user" {
+  default_project_id = openstack_identity_project_v3.user_project.id
+  name               = var.user.username
+  password           = var.user.password
+  description        = format("Cloud User - %s", var.user.username)
+  domain_id          = openstack_identity_project_v3.users_domain.id
+}
+
+# Map existing member role into configuration
+data "openstack_identity_role_v3" "member" {
+  name = "member"
+}
+
+resource "openstack_identity_role_assignment_v3" "role_assignment_1" {
+  user_id    = openstack_identity_user_v3.user.id
+  project_id = openstack_identity_project_v3.user_project.id
+  role_id    = data.openstack_identity_role_v3.member.id
+}
+
+# User networking
+resource "openstack_networking_network_v2" "user_network" {
+  name           = format("%s-network", var.user.username)
+  admin_state_up = true
+  tenant_id      = openstack_identity_project_v3.user_project.id
+}
+
+resource "openstack_networking_subnet_v2" "user_subnet" {
+  name       = format("%s-subnet", var.user.username)
+  network_id = openstack_networking_network_v2.user_network.id
+  tenant_id  = openstack_identity_project_v3.user_project.id
+  cidr       = var.user.cidr
+}
+
+resource "openstack_networking_router_v2" "user_router" {
+  name                = format("%s-router", var.user.username)
+  tenant_id           = openstack_identity_project_v3.user_project.id
+  admin_state_up      = true
+  external_network_id = openstack_networking_network_v2.external_network.id
+}
+
+resource "openstack_networking_router_interface_v2" "user_router_interface" {
+  router_id = openstack_networking_router_v2.user_router.id
+  subnet_id = openstack_networking_subnet_v2.user_subnet.id
+}
+
+# Compute quota - set unlimited as this is a sandbox deployment
+resource "openstack_compute_quotaset_v2" "compute_quota" {
+  project_id           = openstack_identity_project_v3.user_project.id
+  key_pairs            = -1
+  ram                  = -1
+  cores                = -1
+  instances            = -1
+  server_groups        = -1
+  server_group_members = -1
+}
+
+# Network quota - set unlimited as this is a sandbox deployment
+resource "openstack_networking_quota_v2" "network_quota" {
+  project_id          = openstack_identity_project_v3.user_project.id
+  floatingip          = -1
+  network             = -1
+  port                = -1
+  rbac_policy         = -1
+  router              = -1
+  security_group      = -1
+  security_group_rule = -1
+  subnet              = -1
+  subnetpool          = -1
+}
+
+
+data "openstack_networking_secgroup_v2" "secgroup_default" {
+  name      = "default"
+  tenant_id = openstack_identity_project_v3.user_project.id
+}
+
+resource "openstack_networking_secgroup_rule_v2" "secgroup_rule_ssh_ingress" {
+  count             = var.user.security_group_rules ? 1 : 0
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 22
+  port_range_max    = 22
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = data.openstack_networking_secgroup_v2.secgroup_default.id
+  tenant_id         = openstack_identity_project_v3.user_project.id
+}
+
+resource "openstack_networking_secgroup_rule_v2" "secgroup_rule_ping_ingress" {
+  count             = var.user.security_group_rules ? 1 : 0
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "icmp"
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = data.openstack_networking_secgroup_v2.secgroup_default.id
+  tenant_id         = openstack_identity_project_v3.user_project.id
+}

--- a/cloud/etc/demo-setup/outputs.tf
+++ b/cloud/etc/demo-setup/outputs.tf
@@ -1,0 +1,27 @@
+output "OS_USERNAME" {
+  description = "OpenStack username"
+  value       = openstack_identity_user_v3.user.name
+  sensitive   = true
+}
+
+output "OS_PASSWORD" {
+  description = "OpenStack password"
+  value       = openstack_identity_user_v3.user.password
+  sensitive   = true
+}
+
+output "OS_USER_DOMAIN_NAME" {
+  description = "OpenStack user domain name"
+  value       = openstack_identity_project_v3.users_domain.name
+}
+
+output "OS_PROJECT_DOMAIN_NAME" {
+  description = "OpenStack project domain name"
+  value       = openstack_identity_project_v3.users_domain.name
+}
+
+output "OS_PROJECT_NAME" {
+  description = "OpenStack project name"
+  value       = openstack_identity_project_v3.user_project.name
+  sensitive   = true
+}

--- a/cloud/etc/demo-setup/variables.tf
+++ b/cloud/etc/demo-setup/variables.tf
@@ -1,0 +1,24 @@
+# External networking
+variable "external_network" {
+  type = object({
+    cidr             = string
+    gateway          = string
+    start            = string
+    end              = string
+    physical_network = string
+    network_type     = string
+    segmentation_id  = number
+  })
+}
+
+
+# User setup
+variable "user" {
+  type = object({
+    username             = string
+    password             = string
+    cidr                 = string
+    security_group_rules = bool
+  })
+  sensitive = true
+}

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -157,10 +157,9 @@ parts:
   terraform-openstack-plan:
     after: [terraform]
     plugin: dump
-    source: https://github.com/gnuoy/sunbeam-terraform
+    source: https://github.com/openstack-snaps/sunbeam-terraform
     source-depth: 1
     source-type: git
-    source-branch: mysql-constraint
     organize:
       '*': etc/deploy-openstack/
     override-build: |

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -157,9 +157,10 @@ parts:
   terraform-openstack-plan:
     after: [terraform]
     plugin: dump
-    source: https://github.com/openstack-snaps/sunbeam-terraform
+    source: https://github.com/gnuoy/sunbeam-terraform
     source-depth: 1
     source-type: git
+    source-branch: mysql-constraint
     organize:
       '*': etc/deploy-openstack/
     override-build: |

--- a/sunbeam/commands/configure.py
+++ b/sunbeam/commands/configure.py
@@ -100,6 +100,7 @@ def ext_net_questions():
         ),
         "nic": sunbeam.jobs.questions.PromptQuestion(
             "Free network interface microstack can use for external traffic",
+            choices=utils.get_free_nics(),
             default_value=utils.get_free_nic(),
         ),
     }

--- a/sunbeam/commands/configure.py
+++ b/sunbeam/commands/configure.py
@@ -1,0 +1,618 @@
+# Copyright (c) 2022 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import ipaddress
+import json
+import logging
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Optional
+
+import click
+from rich.console import Console
+from snaphelpers import Snap
+
+from sunbeam.clusterd.client import Client
+import sunbeam.jobs.questions
+from sunbeam import utils
+from sunbeam.jobs.juju import (
+    JujuHelper,
+    ModelNotFoundException,
+    run_sync,
+    CONTROLLER_MODEL,
+)
+from sunbeam.commands.terraform import (
+    TerraformException,
+    TerraformHelper,
+    TerraformInitStep,
+)
+from sunbeam.jobs.common import BaseStep, Result, ResultType, Status, run_plan
+from sunbeam.commands.openstack import OPENSTACK_MODEL
+
+CLOUD_CONFIG_SECTION = "CloudConfig"
+LOG = logging.getLogger(__name__)
+console = Console()
+
+
+def user_questions():
+    return {
+        "run_demo_setup": sunbeam.jobs.questions.ConfirmQuestion(
+            "Populate OpenStack cloud with demo user, default images, flavors etc",
+            default_value=True,
+        ),
+        "username": sunbeam.jobs.questions.PromptQuestion(
+            "Username to use for access to OpenStack", default_value="demo"
+        ),
+        "password": sunbeam.jobs.questions.PromptQuestion(
+            "Password to use for access to OpenStack",
+            default_function=utils.generate_password,
+        ),
+        "cidr": sunbeam.jobs.questions.PromptQuestion(
+            "Network range to use for project network", default_value="192.168.122.0/24"
+        ),
+        "security_group_rules": sunbeam.jobs.questions.ConfirmQuestion(
+            "Setup security group rules for SSH and ICMP ingress", default_value=True
+        ),
+        "remote_access_location": sunbeam.jobs.questions.PromptQuestion(
+            "Local or remote access to VMs",
+            choices=[utils.LOCAL_ACCESS, utils.REMOTE_ACCESS],
+            default_value=utils.LOCAL_ACCESS,
+        ),
+    }
+
+
+def ext_net_questions():
+    return {
+        "cidr": sunbeam.jobs.questions.PromptQuestion(
+            "CIDR of network to use for external networking",
+            default_value="10.20.20.0/24",
+        ),
+        "gateway": sunbeam.jobs.questions.PromptQuestion(
+            "IP address of default gateway for external network", default_value=None
+        ),
+        "start": sunbeam.jobs.questions.PromptQuestion(
+            "Start of IP allocation range for external network", default_value=None
+        ),
+        "end": sunbeam.jobs.questions.PromptQuestion(
+            "End of IP allocation range for external network", default_value=None
+        ),
+        "network_type": sunbeam.jobs.questions.PromptQuestion(
+            "Network type for access to external network",
+            choices=["flat", "vlan"],
+            default_value="flat",
+        ),
+        "segmentation_id": sunbeam.jobs.questions.PromptQuestion(
+            "VLAN ID to use for external network", default_value=0
+        ),
+        "nic": sunbeam.jobs.questions.PromptQuestion(
+            "Free network interface microstack can use for external traffic",
+            default_value=utils.get_free_nic(),
+        ),
+    }
+
+
+def ext_net_questions_local_only():
+    return {
+        "cidr": sunbeam.jobs.questions.PromptQuestion(
+            (
+                "CIDR of OpenStack external network - arbitrary but must not "
+                "be in use"
+            ),
+            default_value="10.20.20.0/24",
+        ),
+        "start": sunbeam.jobs.questions.PromptQuestion(
+            "Start of IP allocation range for external network", default_value=None
+        ),
+        "end": sunbeam.jobs.questions.PromptQuestion(
+            "End of IP allocation range for external network", default_value=None
+        ),
+        "network_type": sunbeam.jobs.questions.PromptQuestion(
+            "Network type for access to external network",
+            choices=["flat", "vlan"],
+            default_value="flat",
+        ),
+        "segmentation_id": sunbeam.jobs.questions.PromptQuestion(
+            "VLAN ID to use for external network", default_value=0
+        ),
+    }
+
+
+VARIABLE_DEFAULTS = {
+    "user": {
+        "username": "demo",
+        "cidr": "192.168.122.0/24",
+        "security_group_rules": True,
+    },
+    "external_network": {
+        "cidr": "10.20.20.0/24",
+        "gateway": None,
+        "start": None,
+        "end": None,
+        "physical_network": "physnet1",
+        "network_type": "flat",
+        "segmentation_id": 0,
+    },
+}
+
+
+def _retrieve_admin_credentials(jhelper: JujuHelper, model: str) -> dict:
+    """Retrieve cloud admin credentials.
+
+    Retrieve cloud admin credentials from keystone and
+    return as a dict suitable for use with subprocess
+    commands.  Variables are prefixed with OS_.
+    """
+    app = "keystone"
+    action_cmd = "get-admin-account"
+    unit = run_sync(jhelper.get_leader_unit(app, model))
+    action_result = run_sync(jhelper.run_action(unit, model, action_cmd))
+
+    if action_result.get("return-code", 0) > 1:
+        _message = "Unable to retrieve openrc from Keystone service"
+        raise click.ClickException(_message)
+
+    return {
+        "OS_USERNAME": action_result.get("username"),
+        "OS_PASSWORD": action_result.get("password"),
+        "OS_AUTH_URL": action_result.get("public-endpoint"),
+        "OS_USER_DOMAIN_NAME": action_result.get("user-domain-name"),
+        "OS_PROJECT_DOMAIN_NAME": action_result.get("project-domain-name"),
+        "OS_PROJECT_NAME": action_result.get("project-name"),
+        "OS_AUTH_VERSION": action_result.get("api-version"),
+        "OS_IDENTITY_API_VERSION": action_result.get("api-version"),
+    }
+
+
+class SetHypervisorCharmConfigStep(BaseStep):
+    """Update openstack-hypervisor charm config"""
+
+    IPVANYNETWORK_UNSET = "0.0.0.0/0"
+
+    def __init__(self, jhelper, ext_network: Path):
+        super().__init__(
+            "Update charm config",
+            "Updating openstack-hypervisor charm configuration",
+        )
+
+        # File path with external_network details in json format
+        self.ext_network_file = ext_network
+        self.ext_network = {}
+        self.client = Client()
+        self.jhelper = jhelper
+        self.charm_config = {}
+
+    def has_prompts(self) -> bool:
+        return False
+
+    def run(self, status: Optional["Status"] = None) -> Result:
+        """Run the step to completion.
+
+        Invoked when the step is run and returns a ResultType to indicate
+
+        :return:
+        """
+        self.variables = sunbeam.jobs.questions.load_answers(
+            self.client, CLOUD_CONFIG_SECTION
+        )
+        self.ext_network = self.variables.get("external_network", {})
+        self.charm_config["enable-gateway"] = str(
+            self.variables["user"]["remote_access_location"] == utils.REMOTE_ACCESS
+        )
+        self.charm_config["external-bridge"] = "br-ex"
+        if self.variables["user"]["remote_access_location"] == utils.LOCAL_ACCESS:
+            external_network = ipaddress.ip_network(
+                self.variables["external_network"].get("cidr")
+            )
+            bridge_interface = (
+                f"{self.ext_network.get('gateway')}/{external_network.prefixlen}"
+            )
+            self.charm_config["external-bridge-address"] = bridge_interface
+        else:
+            self.charm_config["external-bridge-address"] = self.IPVANYNETWORK_UNSET
+
+        self.charm_config["physnet-name"] = self.variables["external_network"].get(
+            "physical_network"
+        )
+        try:
+            model = CONTROLLER_MODEL.split("/")[-1]
+            LOG.debug(
+                f"Config to apply on openstack-hypervisor snap: {self.charm_config}"
+            )
+            run_sync(
+                self.jhelper.set_application_config(
+                    model,
+                    "openstack-hypervisor",
+                    self.charm_config,
+                )
+            )
+        except Exception as e:
+            LOG.exception("Error setting config for openstack-hypervisor")
+            return Result(ResultType.FAILED, str(e))
+
+        return Result(ResultType.COMPLETED)
+
+
+class UserOpenRCStep(BaseStep):
+    """Generate openrc for created cloud user."""
+
+    def __init__(self, auth_url: str, auth_version: str, openrc: str):
+        super().__init__("Generate user openrc", "Generating openrc for cloud usage")
+        self.auth_url = auth_url
+        self.auth_version = auth_version
+        self.openrc = openrc
+        self.client = Client()
+
+    def is_skip(self, status: Optional[Status] = None) -> Result:
+        """Determines if the step should be skipped or not.
+
+        :return: ResultType.SKIPPED if the Step should be skipped,
+                 ResultType.COMPLETED or ResultType.FAILED otherwise
+        """
+        self.variables = sunbeam.jobs.questions.load_answers(
+            self.client, CLOUD_CONFIG_SECTION
+        )
+        if self.variables["user"]["run_demo_setup"]:
+            return Result(ResultType.COMPLETED)
+        else:
+            return Result(ResultType.SKIPPED)
+
+    def run(self, status: Optional["Status"] = None) -> Result:
+        try:
+            snap = Snap()
+            terraform = str(snap.paths.snap / "bin" / "terraform")
+            cmd = [terraform, "output", "-json"]
+            LOG.debug(f'Running command {" ".join(cmd)}')
+            process = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                check=True,
+                cwd=snap.paths.user_common / "etc" / "demo-setup",
+            )
+            LOG.debug(
+                f"Command finished. stdout={process.stdout}, stderr={process.stderr}"
+            )
+            tf_output = json.loads(process.stdout)
+            self._print_openrc(tf_output)
+            return Result(ResultType.COMPLETED)
+        except subprocess.CalledProcessError as e:
+            LOG.exception("Error initializing Terraform")
+            return Result(ResultType.FAILED, str(e))
+
+    def _print_openrc(self, tf_output: dict) -> None:
+        """Print openrc to console and save to disk using provided information"""
+        _openrc = f"""# openrc for {tf_output["OS_USERNAME"]["value"]}
+export OS_AUTH_URL={self.auth_url}
+export OS_USERNAME={tf_output["OS_USERNAME"]["value"]}
+export OS_PASSWORD={tf_output["OS_PASSWORD"]["value"]}
+export OS_USER_DOMAIN_NAME={tf_output["OS_USER_DOMAIN_NAME"]["value"]}
+export OS_PROJECT_DOMAIN_NAME={tf_output["OS_PROJECT_DOMAIN_NAME"]["value"]}
+export OS_PROJECT_NAME={tf_output["OS_PROJECT_NAME"]["value"]}
+export OS_AUTH_VERSION={self.auth_version}
+export OS_IDENTITY_API_VERSION={self.auth_version}"""
+        if self.openrc:
+            message = f"Writing openrc to {self.openrc} ... "
+            console.status(message)
+            with open(self.openrc, "w") as f_openrc:
+                os.fchmod(f_openrc.fileno(), mode=0o640)
+                f_openrc.write(_openrc)
+            console.print(f"{message}[green]done[/green]")
+        else:
+            console.print(_openrc)
+
+
+class UserQuestions(BaseStep):
+    """Ask user configuration questions."""
+
+    def __init__(
+        self,
+        answer_file: str,
+        preseed_file: str = None,
+        accept_defaults: bool = False,
+    ):
+        super().__init__("Ask configure questions", "Ask configure questions")
+        self.accept_defaults = accept_defaults
+        self.preseed_file = preseed_file
+        self.client = Client()
+        self.answer_file = answer_file
+
+    def has_prompts(self) -> bool:
+        return True
+
+    def prompt(self, console: Optional[Console] = None) -> None:
+        """Prompt the user for basic cloud configuration.
+
+        Prompts the user for required information for cloud configuration.
+
+        :param console: the console to prompt on
+        :type console: rich.console.Console (Optional)
+        """
+        self.variables = sunbeam.jobs.questions.load_answers(
+            self.client, CLOUD_CONFIG_SECTION
+        )
+        for section in ["user", "external_network"]:
+            if not self.variables.get(section):
+                self.variables[section] = {}
+        if self.preseed_file:
+            preseed = sunbeam.jobs.questions.read_preseed(self.preseed_file)
+        else:
+            preseed = {}
+        user_bank = sunbeam.jobs.questions.QuestionBank(
+            questions=user_questions(),
+            console=console,
+            preseed=preseed.get("user"),
+            previous_answers=self.variables.get("user"),
+            accept_defaults=self.accept_defaults,
+        )
+        self.variables["user"][
+            "remote_access_location"
+        ] = user_bank.remote_access_location.ask()
+        # External Network Configuration
+        if self.variables["user"]["remote_access_location"] == utils.LOCAL_ACCESS:
+            ext_net_bank = sunbeam.jobs.questions.QuestionBank(
+                questions=ext_net_questions_local_only(),
+                console=console,
+                preseed=preseed.get("external_network"),
+                previous_answers=self.variables.get("external_network"),
+                accept_defaults=self.accept_defaults,
+            )
+        else:
+            ext_net_bank = sunbeam.jobs.questions.QuestionBank(
+                questions=ext_net_questions(),
+                console=console,
+                preseed=preseed.get("external_network"),
+                previous_answers=self.variables.get("external_network"),
+                accept_defaults=self.accept_defaults,
+            )
+        self.variables["external_network"]["cidr"] = ext_net_bank.cidr.ask()
+        external_network = ipaddress.ip_network(
+            self.variables["external_network"]["cidr"]
+        )
+        external_network_hosts = list(external_network.hosts())
+        default_gateway = self.variables["external_network"].get("gateway") or str(
+            external_network_hosts[0]
+        )
+        if self.variables["user"]["remote_access_location"] == utils.LOCAL_ACCESS:
+            self.variables["external_network"]["gateway"] = default_gateway
+        else:
+            self.variables["external_network"]["gateway"] = ext_net_bank.gateway.ask(
+                new_default=default_gateway
+            )
+        self.variables["external_network"]["physical_network"] = VARIABLE_DEFAULTS[
+            "external_network"
+        ]["physical_network"]
+        self.variables["user"]["run_demo_setup"] = user_bank.run_demo_setup.ask()
+        if self.variables["user"]["run_demo_setup"]:
+            # User configuration
+            self.variables["user"]["username"] = user_bank.username.ask()
+            self.variables["user"]["password"] = user_bank.password.ask()
+            self.variables["user"]["cidr"] = user_bank.cidr.ask()
+            self.variables["user"][
+                "security_group_rules"
+            ] = user_bank.security_group_rules.ask()
+            default_allocation_range_start = self.variables["external_network"].get(
+                "start"
+            ) or str(external_network_hosts[1])
+            self.variables["external_network"]["start"] = ext_net_bank.start.ask(
+                new_default=default_allocation_range_start
+            )
+            default_allocation_range_end = self.variables["external_network"].get(
+                "end"
+            ) or str(external_network_hosts[-1])
+            self.variables["external_network"]["end"] = ext_net_bank.end.ask(
+                new_default=default_allocation_range_end
+            )
+
+            self.variables["external_network"][
+                "network_type"
+            ] = ext_net_bank.network_type.ask()
+            if self.variables["external_network"]["network_type"] == "vlan":
+                self.variables["external_network"][
+                    "segmentation_id"
+                ] = ext_net_bank.segmentation_id.ask()
+            else:
+                self.variables["external_network"]["segmentation_id"] = 0
+
+        sunbeam.jobs.questions.write_answers(
+            self.client, CLOUD_CONFIG_SECTION, self.variables
+        )
+
+    def run(self, status: Optional[Status] = None) -> Result:
+        return Result(ResultType.COMPLETED)
+
+
+class DemoSetup(BaseStep):
+    """Default cloud configuration for all-in-one install."""
+
+    def __init__(
+        self,
+        tfhelper: TerraformHelper,
+        answer_file: str,
+    ):
+        super().__init__("Setup demo artifacts", "Setup demo artifacts")
+        self.answer_file = answer_file
+        self.tfhelper = tfhelper
+        self.client = Client()
+
+    def is_skip(self, status: Optional[Status] = None) -> Result:
+        """Determines if the step should be skipped or not.
+
+        :return: ResultType.SKIPPED if the Step should be skipped,
+                 ResultType.COMPLETED or ResultType.FAILED otherwise
+        """
+        self.variables = sunbeam.jobs.questions.load_answers(
+            self.client, CLOUD_CONFIG_SECTION
+        )
+        if self.variables["user"]["run_demo_setup"]:
+            return Result(ResultType.COMPLETED)
+        else:
+            return Result(ResultType.SKIPPED)
+
+    def run(self, status: Optional[Status] = None) -> Result:
+        """Execute configuration using terraform."""
+        self.variables = sunbeam.jobs.questions.load_answers(
+            self.client, CLOUD_CONFIG_SECTION
+        )
+        self.tfhelper.write_tfvars(self.variables, self.answer_file)
+        try:
+            self.tfhelper.apply()
+            return Result(ResultType.COMPLETED)
+        except TerraformException as e:
+            LOG.exception("Error configuring cloud")
+            return Result(ResultType.FAILED, str(e))
+
+
+class TerraformDemoInitStep(TerraformInitStep):
+    def __init__(
+        self,
+        tfhelper: TerraformHelper,
+    ):
+        super().__init__(tfhelper)
+        self.tfhelper = tfhelper
+        self.client = Client()
+
+    def is_skip(self, status: Optional[Status] = None) -> Result:
+        """Determines if the step should be skipped or not.
+
+        :return: ResultType.SKIPPED if the Step should be skipped,
+                 ResultType.COMPLETED or ResultType.FAILED otherwise
+        """
+        self.variables = sunbeam.jobs.questions.load_answers(
+            self.client, CLOUD_CONFIG_SECTION
+        )
+        if self.variables["user"]["run_demo_setup"]:
+            return Result(ResultType.COMPLETED)
+        else:
+            return Result(ResultType.SKIPPED)
+
+
+class SetLocalHypervisorOptions(BaseStep):
+    def __init__(
+        self,
+        name,
+        jhelper,
+    ):
+        super().__init__(
+            "Apply local hypervisor settings", "Apply local hypervisor settings"
+        )
+        self.name = name
+        self.jhelper = jhelper
+        self.client = Client()
+
+    def has_prompts(self) -> bool:
+        return True
+
+    def prompt(self, console: Optional[Console] = None) -> None:
+        self.nic = None
+        self.variables = sunbeam.jobs.questions.load_answers(
+            self.client, CLOUD_CONFIG_SECTION
+        )
+        if self.variables["user"]["remote_access_location"] == utils.REMOTE_ACCESS:
+            ext_net_bank = sunbeam.jobs.questions.QuestionBank(
+                questions=ext_net_questions(),
+                console=console,
+                preseed={},
+                previous_answers={},
+                accept_defaults=False,
+            )
+            self.nic = ext_net_bank.nic.ask()
+
+    def run(self, status: Optional[Status] = None) -> Result:
+        if not self.nic:
+            return Result(ResultType.COMPLETED)
+        node = self.client.cluster.get_node_info(self.name)
+        self.machine_id = str(node.get("machineid"))
+        app = "openstack-hypervisor"
+        action_cmd = "set-hypervisor-local-settings"
+        model = CONTROLLER_MODEL.split("/")[-1]
+        unit = run_sync(self.jhelper.get_unit_from_machine(app, self.machine_id, model))
+        action_result = run_sync(
+            self.jhelper.run_action(
+                unit.entity_id,
+                model,
+                action_cmd,
+                action_params={
+                    "external-nic": self.nic,
+                },
+            )
+        )
+
+        if action_result.get("return-code", 0) > 1:
+            _message = "Unable to set local hypervisor config"
+            raise click.ClickException(_message)
+        return Result(ResultType.COMPLETED)
+
+
+@click.command()
+@click.option("-a", "--accept-defaults", help="Accept all defaults.", is_flag=True)
+@click.option("-p", "--preseed", help="Preseed file.")
+@click.option("-o", "--openrc", help="Output file for cloud access details.")
+def configure(
+    openrc: str = None, preseed: str = None, accept_defaults: bool = False
+) -> None:
+    """Configure cloud with some sane defaults."""
+    name = utils.get_fqdn()
+    snap = Snap()
+    src = snap.paths.snap / "etc" / "demo-setup/"
+    dst = snap.paths.user_common / "etc" / "demo-setup"
+    try:
+        os.mkdir(dst)
+    except FileExistsError:
+        pass
+    # NOTE: install to user writable location
+    LOG.debug(f"Updating {dst} from {src}...")
+    shutil.copytree(src, dst, dirs_exist_ok=True)
+
+    data_location = snap.paths.user_data
+    jhelper = JujuHelper(data_location)
+    try:
+        run_sync(jhelper.get_model(OPENSTACK_MODEL))
+    except ModelNotFoundException:
+        LOG.error(f"Expected model {OPENSTACK_MODEL} missing")
+        raise click.ClickException(
+            "Please run `openstack.sunbeam cluster bootstrap` first"
+        )
+    admin_credentials = _retrieve_admin_credentials(jhelper, OPENSTACK_MODEL)
+    tfhelper = TerraformHelper(
+        path=snap.paths.user_common / "etc" / "demo-setup",
+        env=admin_credentials,
+        plan="demo-setup",
+        parallelism=1,
+        backend="http",
+        data_location=data_location,
+    )
+    answer_file = tfhelper.path / "config.auto.tfvars.json"
+    plan = [
+        UserQuestions(
+            answer_file=answer_file,
+            preseed_file=preseed,
+            accept_defaults=accept_defaults,
+        ),
+        TerraformDemoInitStep(tfhelper),
+        DemoSetup(
+            tfhelper=tfhelper,
+            answer_file=answer_file,
+        ),
+        UserOpenRCStep(
+            auth_url=admin_credentials["OS_AUTH_URL"],
+            auth_version=admin_credentials["OS_AUTH_VERSION"],
+            openrc=openrc,
+        ),
+        SetHypervisorCharmConfigStep(jhelper, ext_network=answer_file),
+        SetLocalHypervisorOptions(name, jhelper),
+    ]
+    run_plan(plan, console)

--- a/sunbeam/commands/configure.py
+++ b/sunbeam/commands/configure.py
@@ -159,9 +159,13 @@ def _retrieve_admin_credentials(jhelper: JujuHelper, model: str) -> dict:
     """
     app = "keystone"
     action_cmd = "get-admin-account"
-    unit = run_sync(jhelper.get_leader_unit(app, model))
-    action_result = run_sync(jhelper.run_action(unit, model, action_cmd))
 
+    unit_action_result = run_sync(jhelper.get_leader_unit(app, model))
+    if unit_action_result.get("return-code", 0) > 1:
+        _message = f"Unable to get {app} leader"
+        raise click.ClickException(_message)
+
+    action_result = run_sync(jhelper.run_action(unit, model, action_cmd))
     if action_result.get("return-code", 0) > 1:
         _message = "Unable to retrieve openrc from Keystone service"
         raise click.ClickException(_message)
@@ -572,7 +576,7 @@ class SetLocalHypervisorOptions(BaseStep):
 
         if action_result.get("return-code", 0) > 1:
             _message = "Unable to set local hypervisor config"
-            raise click.ClickException(_message)
+            return Result(ResultType.FAILED, _message)
         return Result(ResultType.COMPLETED)
 
 

--- a/sunbeam/commands/node.py
+++ b/sunbeam/commands/node.py
@@ -28,6 +28,9 @@ from sunbeam.commands.clusterd import (
     ClusterRemoveNodeStep,
     ClusterUpdateNodeStep,
 )
+from sunbeam.commands.configure import (
+    SetLocalHypervisorOptions,
+)
 from sunbeam.commands.hypervisor import AddHypervisorUnitStep
 from sunbeam.commands.juju import AddJujuMachineStep  # RemoveJujuUserStep,
 from sunbeam.commands.juju import (
@@ -132,7 +135,12 @@ def join(token: str, role: str) -> None:
         plan2.append(AddMicrok8sUnitStep(name, jhelper))
 
     if Role[role.upper()].is_compute_node():
-        plan2.append(AddHypervisorUnitStep(name, jhelper))
+        plan2.extend(
+            [
+                AddHypervisorUnitStep(name, jhelper),
+                SetLocalHypervisorOptions(name, jhelper),
+            ]
+        )
 
     run_plan(plan2, console)
 

--- a/sunbeam/commands/node.py
+++ b/sunbeam/commands/node.py
@@ -138,7 +138,7 @@ def join(token: str, role: str) -> None:
         plan2.extend(
             [
                 AddHypervisorUnitStep(name, jhelper),
-                SetLocalHypervisorOptions(name, jhelper),
+                SetLocalHypervisorOptions(name, jhelper, join_mode=True),
             ]
         )
 

--- a/sunbeam/jobs/juju.py
+++ b/sunbeam/jobs/juju.py
@@ -245,6 +245,23 @@ class JujuHelper:
             )
         return unit
 
+    @controller
+    async def get_unit_from_machine(
+        self, application: str, machine_id: int, model: str
+    ) -> Unit:
+        """Fetch a application's unit in model on a specific machine.
+
+        :application: application name of the unit to look for
+        :machine_id: Id of machine unit is on
+        :model: Name of the model where the unit is located"""
+        model_impl = await self.get_model(model)
+        application = model_impl.applications.get(application)
+        unit = None
+        for u in application.units:
+            if machine_id == u.machine.entity_id:
+                unit = u
+        return unit
+
     def _validate_unit(self, unit: str):
         """Validate unit name."""
         parts = unit.split("/")
@@ -513,3 +530,14 @@ class JujuHelper:
             raise TimeoutException(
                 f"Timed out while waiting for model {model!r} to be ready"
             ) from e
+
+    @controller
+    async def set_application_config(self, model: str, app: str, config: dict):
+        """Update application configuration
+
+        :model: Name of the model to wait for readiness
+        :application: Application to update
+        :config: Config to be set
+        """
+        model_impl = await self.get_model(model)
+        await model_impl.applications[app].set_config(config)

--- a/sunbeam/jobs/questions.py
+++ b/sunbeam/jobs/questions.py
@@ -20,7 +20,7 @@ from typing import Any, Callable, Optional
 
 import yaml
 from rich.console import Console
-from rich.prompt import Prompt
+from rich.prompt import Confirm, Prompt
 
 from sunbeam.clusterd.client import Client
 from sunbeam.clusterd.service import ConfigItemNotFoundException
@@ -117,6 +117,14 @@ class PromptQuestion(Question):
     @property
     def question_function(self):
         return Prompt.ask
+
+
+class ConfirmQuestion(Question):
+    """Ask the user a simple yes / no question."""
+
+    @property
+    def question_function(self):
+        return Confirm.ask
 
 
 class QuestionBank:

--- a/sunbeam/main.py
+++ b/sunbeam/main.py
@@ -19,6 +19,7 @@ import click
 
 from sunbeam import log
 from sunbeam.commands import bootstrap as bootstrap_cmds
+from sunbeam.commands import configure as configure_cmds
 from sunbeam.commands import node as node_cmds
 from sunbeam.commands import ssh_init as ssh_init_cmds
 
@@ -51,6 +52,7 @@ def cluster(ctx):
 def main():
     log.setup_root_logging()
     cli.add_command(cluster)
+    cli.add_command(configure_cmds.configure)
     cluster.add_command(bootstrap_cmds.bootstrap)
     cluster.add_command(node_cmds.add_node)
     cluster.add_command(node_cmds.join)

--- a/sunbeam/utils.py
+++ b/sunbeam/utils.py
@@ -13,9 +13,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import glob
+import logging
 import socket
+from pathlib import Path
 
 import netifaces
+import pwgen
+
+LOG = logging.getLogger(__name__)
+LOCAL_ACCESS = "local"
+REMOTE_ACCESS = "remote"
 
 
 def get_fqdn() -> str:
@@ -37,3 +45,58 @@ def get_local_ip_by_default_route() -> str:
         ip = ip_list[0]["addr"]
 
     return ip
+
+
+def get_nic_macs(nic: str) -> list:
+    """Return list of mac addresses associates with nic."""
+    addrs = netifaces.ifaddresses(nic)
+    return sorted([a["addr"] for a in addrs[netifaces.AF_LINK]])
+
+
+def is_configured(nic: str) -> bool:
+    """Whether interface is configured with IPv4 or IPv6 address."""
+    addrs = netifaces.ifaddresses(nic)
+    return bool(addrs.get(netifaces.AF_INET) or addrs.get(netifaces.AF_INET6))
+
+
+def get_free_nics() -> list:
+    """Return a list of nics which doe not have a v4 or v6 address."""
+    virtual_nic_dir = "/sys/devices/virtual/net/*"
+    virtual_nics = [Path(p).name for p in glob.glob(virtual_nic_dir)]
+    bond_nic_dir = "/proc/net/bonding/*"
+    bonds = [Path(p).name for p in glob.glob(bond_nic_dir)]
+    bond_macs = []
+    for bond_iface in bonds:
+        bond_macs.extend(get_nic_macs(bond_iface))
+    candidate_nics = []
+    for nic in netifaces.interfaces():
+        if nic in bonds and not is_configured(nic):
+            LOG.debug(f"Found bond {nic}")
+            candidate_nics.append(nic)
+            continue
+        macs = get_nic_macs(nic)
+        if list(set(macs) & set(bond_macs)):
+            LOG.debug(f"Skipping {nic} it is part of a bond")
+            continue
+        if nic in virtual_nics:
+            LOG.debug(f"Skipping {nic} it is virtual")
+            continue
+        if is_configured(nic):
+            LOG.debug(f"Skipping {nic} it is configured")
+        else:
+            LOG.debug(f"Found nic {nic}")
+            candidate_nics.append(nic)
+    return candidate_nics
+
+
+def get_free_nic() -> str:
+    nics = get_free_nics()
+    nic = ""
+    if len(nics) > 0:
+        nic = nics[0]
+    return nic
+
+
+def generate_password() -> str:
+    """Generate a password."""
+    return pwgen.pwgen(12)

--- a/tests/unit/sunbeam/commands/test_configure.py
+++ b/tests/unit/sunbeam/commands/test_configure.py
@@ -322,6 +322,17 @@ class TestSetLocalHypervisorOptions:
         step.prompt()
         assert step.nic == "eth12"
 
+    def test_prompt_remote_join(self, cclient, jhelper, load_answers, question_bank):
+        load_answers.return_value = {"user": {"remote_access_location": "remote"}}
+        ext_net_bank_mock = Mock()
+        question_bank.return_value = ext_net_bank_mock
+        ext_net_bank_mock.nic.ask.return_value = "eth12"
+        step = configure.SetLocalHypervisorOptions(
+            "maas0.local", jhelper, join_mode=True
+        )
+        step.prompt()
+        assert step.nic == "eth12"
+
     def test_prompt_local(self, cclient, jhelper, load_answers, question_bank):
         load_answers.return_value = {"user": {"remote_access_location": "local"}}
         ext_net_bank_mock = Mock()
@@ -330,6 +341,17 @@ class TestSetLocalHypervisorOptions:
         step = configure.SetLocalHypervisorOptions("maas0.local", jhelper)
         step.prompt()
         assert step.nic is None
+
+    def test_prompt_local_join(self, cclient, jhelper, load_answers, question_bank):
+        load_answers.return_value = {"user": {"remote_access_location": "local"}}
+        ext_net_bank_mock = Mock()
+        question_bank.return_value = ext_net_bank_mock
+        ext_net_bank_mock.nic.ask.return_value = "eth12"
+        step = configure.SetLocalHypervisorOptions(
+            "maas0.local", jhelper, join_mode=True
+        )
+        step.prompt()
+        assert step.nic == "eth12"
 
     def test_run(self, cclient, jhelper):
         jhelper.run_action.return_value = {"return-code": 0}

--- a/tests/unit/sunbeam/commands/test_configure.py
+++ b/tests/unit/sunbeam/commands/test_configure.py
@@ -1,0 +1,364 @@
+# Copyright 2023 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, Mock, patch
+
+import click
+import pytest
+
+import sunbeam.commands.configure as configure
+import sunbeam.jobs.questions
+from sunbeam.commands.terraform import TerraformException
+from sunbeam.jobs.common import ResultType
+
+
+@pytest.fixture(autouse=True)
+def mock_run_sync(mocker):
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+
+    def run_sync(coro):
+        return loop.run_until_complete(coro)
+
+    mocker.patch("sunbeam.commands.configure.run_sync", run_sync)
+    yield
+    loop.close()
+
+
+@pytest.fixture()
+def cclient():
+    with patch("sunbeam.commands.configure.Client") as p:
+        yield p
+
+
+@pytest.fixture()
+def load_answers():
+    with patch.object(sunbeam.jobs.questions, "load_answers") as p:
+        yield p
+
+
+@pytest.fixture()
+def write_answers():
+    with patch.object(sunbeam.jobs.questions, "write_answers") as p:
+        yield p
+
+
+@pytest.fixture()
+def question_bank():
+    with patch.object(sunbeam.jobs.questions, "QuestionBank") as p:
+        yield p
+
+
+@pytest.fixture()
+def jhelper():
+    yield AsyncMock()
+
+
+@pytest.fixture()
+def thelper():
+    yield Mock(path=Path())
+
+
+class SetHypervisorCharmConfigStep:
+    def test_is_skip(self, cclient, jhelper):
+        step = configure.SetHypervisorCharmConfigStep(jhelper, "/tmp/dummypath")
+        result = step.is_skip()
+        assert result.result_type == ResultType.COMPLETED
+
+    def test_run_remote_access(self, load_answers, jhelper, cclient):
+        load_answers.return_value = {
+            "user": {"remote_access_location": "remote"},
+            "external_network": {"physical_network": "physnet1"},
+        }
+        step = configure.SetHypervisorCharmConfigStep(jhelper, "/tmp/dummypath")
+        step.run()
+        jhelper.set_application_config.assert_called_once_with(
+            "controller",
+            "openstack-hypervisor",
+            {
+                "enable-gateway": "True",
+                "external-bridge": "br-ex",
+                "external-bridge-address": "0.0.0.0/0",
+                "physnet-name": "physnet1",
+            },
+        )
+
+    def test_run_remote_access_local(self, load_answers, jhelper, cclient):
+        load_answers.return_value = {
+            "user": {"remote_access_location": "local"},
+            "external_network": {
+                "gateway": "10.0.0.1",
+                "cidr": "10.0.0.0/16",
+                "physical_network": "physnet1",
+            },
+        }
+        step = configure.SetHypervisorCharmConfigStep(jhelper, "/tmp/dummypath")
+        step.run()
+        jhelper.set_application_config.assert_called_once_with(
+            "controller",
+            "openstack-hypervisor",
+            {
+                "enable-gateway": "False",
+                "external-bridge": "br-ex",
+                "external-bridge-address": "10.0.0.1/16",
+                "physnet-name": "physnet1",
+            },
+        )
+
+
+class TestUserQuestions:
+    def test_has_prompts(self, cclient):
+        step = configure.UserQuestions(jhelper)
+        assert step.has_prompts()
+
+    def check_common_questions(self, bank_mock):
+        assert bank_mock.username.ask.called
+
+    def check_demo_questions(self, user_bank_mock, net_bank_mock):
+        assert user_bank_mock.username.ask.called
+        assert user_bank_mock.password.ask.called
+        assert user_bank_mock.cidr.ask.called
+        assert user_bank_mock.security_group_rules.ask.called
+        assert net_bank_mock.start.ask.called
+        assert net_bank_mock.end.ask.called
+        assert net_bank_mock.network_type.ask.called
+        assert net_bank_mock.segmentation_id.ask.called
+
+    def check_not_demo_questions(self, user_bank_mock, net_bank_mock):
+        assert not user_bank_mock.username.ask.called
+        assert not user_bank_mock.password.ask.called
+        assert not user_bank_mock.cidr.ask.called
+        assert not user_bank_mock.security_group_rules.ask.called
+        assert not net_bank_mock.start.ask.called
+        assert not net_bank_mock.end.ask.called
+        assert not net_bank_mock.network_type.ask.called
+
+    def check_remote_questions(self, net_bank_mock):
+        assert net_bank_mock.gateway.ask.called
+
+    def check_not_remote_questions(self, net_bank_mock):
+        assert not net_bank_mock.gateway.ask.called
+
+    def set_net_common_answers(self, net_bank_mock):
+        net_bank_mock.network_type.ask.return_value = "vlan"
+        net_bank_mock.cidr.ask.return_value = "10.0.0.0/24"
+
+    def configure_mocks(self, question_bank):
+        user_bank_mock = Mock()
+        net_bank_mock = Mock()
+        bank_mocks = [net_bank_mock, user_bank_mock]
+        question_bank.side_effect = lambda *args, **kwargs: bank_mocks.pop()
+        self.set_net_common_answers(net_bank_mock)
+        return user_bank_mock, net_bank_mock
+
+    def test_prompt_remote_demo_setup(
+        self, cclient, load_answers, question_bank, write_answers
+    ):
+        load_answers.return_value = {}
+        user_bank_mock, net_bank_mock = self.configure_mocks(question_bank)
+        user_bank_mock.remote_access_location.ask.return_value = "remote"
+        user_bank_mock.run_demo_setup.ask.return_value = True
+        step = configure.UserQuestions(jhelper)
+        step.prompt()
+        self.check_demo_questions(user_bank_mock, net_bank_mock)
+        self.check_remote_questions(net_bank_mock)
+
+    def test_prompt_remote_no_demo_setup(
+        self, cclient, load_answers, question_bank, write_answers
+    ):
+        load_answers.return_value = {}
+        user_bank_mock, net_bank_mock = self.configure_mocks(question_bank)
+        user_bank_mock.remote_access_location.ask.return_value = "remote"
+        user_bank_mock.run_demo_setup.ask.return_value = False
+        step = configure.UserQuestions(jhelper)
+        step.prompt()
+        self.check_not_demo_questions(user_bank_mock, net_bank_mock)
+        self.check_remote_questions(net_bank_mock)
+
+    def test_prompt_local_demo_setup(
+        self, cclient, load_answers, question_bank, write_answers
+    ):
+        load_answers.return_value = {}
+        user_bank_mock, net_bank_mock = self.configure_mocks(question_bank)
+        user_bank_mock.remote_access_location.ask.return_value = "local"
+        user_bank_mock.run_demo_setup.ask.return_value = True
+        step = configure.UserQuestions(jhelper)
+        step.prompt()
+        self.check_demo_questions(user_bank_mock, net_bank_mock)
+        self.check_not_remote_questions(net_bank_mock)
+
+    def test_prompt_local_no_demo_setup(
+        self, cclient, load_answers, question_bank, write_answers
+    ):
+        load_answers.return_value = {}
+        user_bank_mock, net_bank_mock = self.configure_mocks(question_bank)
+        user_bank_mock.remote_access_location.ask.return_value = "local"
+        user_bank_mock.run_demo_setup.ask.return_value = False
+        step = configure.UserQuestions(jhelper)
+        step.prompt()
+        self.check_not_demo_questions(user_bank_mock, net_bank_mock)
+        self.check_not_remote_questions(net_bank_mock)
+
+
+class TestUserOpenRCStep:
+    def test_is_skip_with_demo(self, tmpdir, cclient, load_answers):
+        outfile = tmpdir + "/" + "openrc"
+        load_answers.return_value = {"user": {"run_demo_setup": True}}
+        step = configure.UserOpenRCStep("http://keystone:5000", "3", outfile)
+        result = step.is_skip()
+        assert result.result_type == ResultType.COMPLETED
+
+    def test_is_skip(self, tmpdir, cclient, load_answers):
+        outfile = tmpdir + "/" + "openrc"
+        load_answers.return_value = {"user": {"run_demo_setup": False}}
+        step = configure.UserOpenRCStep("http://keystone:5000", "3", outfile)
+        result = step.is_skip()
+        assert result.result_type == ResultType.SKIPPED
+
+    def test_run(self, mocker, tmpdir, cclient, run, snap, environ):
+        mocker.patch.object(configure, "Snap", return_value=snap)
+        environ.copy.return_value = {}
+        outfile = tmpdir + "/" + "openrc"
+        runout_mock = Mock()
+        creds = {
+            "OS_USERNAME": {"value": "user1"},
+            "OS_PASSWORD": {"value": "reallyhardpassword"},
+            "OS_USER_DOMAIN_NAME": {"value": "userdomain"},
+            "OS_PROJECT_DOMAIN_NAME": {"value": "projectdomain"},
+            "OS_PROJECT_NAME": {"value": "projectname"},
+        }
+        runout_mock.stdout = json.dumps(creds)
+        runout_mock.sterr = ""
+        run.return_value = runout_mock
+        auth_url = "http://keystone:5000"
+        auth_version = 3
+        step = configure.UserOpenRCStep(auth_url, "3", outfile)
+        step.run()
+        with open(outfile, "r") as f:
+            contents = f.read()
+        expect = f"""# openrc for {creds["OS_USERNAME"]["value"]}
+export OS_AUTH_URL={auth_url}
+export OS_USERNAME={creds["OS_USERNAME"]["value"]}
+export OS_PASSWORD={creds["OS_PASSWORD"]["value"]}
+export OS_USER_DOMAIN_NAME={creds["OS_USER_DOMAIN_NAME"]["value"]}
+export OS_PROJECT_DOMAIN_NAME={creds["OS_PROJECT_DOMAIN_NAME"]["value"]}
+export OS_PROJECT_NAME={creds["OS_PROJECT_NAME"]["value"]}
+export OS_AUTH_VERSION={auth_version}
+export OS_IDENTITY_API_VERSION={auth_version}"""
+        assert contents == expect
+
+
+class TestDemoSetup:
+    def test_is_skip_demo_setup(self, cclient, thelper, load_answers):
+        load_answers.return_value = {"user": {"run_demo_setup": True}}
+        step = configure.DemoSetup(thelper, "/tmp/dummy")
+        result = step.is_skip()
+        assert result.result_type == ResultType.COMPLETED
+
+    def test_is_skip(self, cclient, thelper, load_answers):
+        load_answers.return_value = {"user": {"run_demo_setup": False}}
+        step = configure.DemoSetup(thelper, "/tmp/dummy")
+        result = step.is_skip()
+        assert result.result_type == ResultType.SKIPPED
+
+    def test_run(self, cclient, thelper, load_answers):
+        answer_data = {"user": {"foo": "bar"}}
+        load_answers.return_value = answer_data
+        step = configure.DemoSetup(thelper, "/tmp/dummy")
+        result = step.run()
+        thelper.write_tfvars.assert_called_once_with(answer_data, "/tmp/dummy")
+        assert result.result_type == ResultType.COMPLETED
+
+    def test_run_fail(self, cclient, thelper, load_answers):
+        answer_data = {"user": {"foo": "bar"}}
+        load_answers.return_value = answer_data
+        thelper.apply.side_effect = TerraformException("Bad terraform")
+        step = configure.DemoSetup(thelper, "/tmp/dummy")
+        result = step.run()
+        assert result.result_type == ResultType.FAILED
+
+
+class TestTerraformDemoInitStep:
+    def test_is_skip_demo_setup(self, cclient, thelper, load_answers):
+        load_answers.return_value = {"user": {"run_demo_setup": True}}
+        step = configure.TerraformDemoInitStep(thelper)
+        result = step.is_skip()
+        assert result.result_type == ResultType.COMPLETED
+
+    def test_is_skip(self, cclient, thelper, load_answers):
+        load_answers.return_value = {"user": {"run_demo_setup": False}}
+        step = configure.TerraformDemoInitStep(thelper)
+        result = step.is_skip()
+        assert result.result_type == ResultType.SKIPPED
+
+
+class TestSetLocalHypervisorOptions:
+    def test_has_prompts(self, cclient, jhelper):
+        step = configure.SetLocalHypervisorOptions("maas0.local", jhelper)
+        assert step.has_prompts()
+
+    def test_prompt_remote(self, cclient, jhelper, load_answers, question_bank):
+        load_answers.return_value = {"user": {"remote_access_location": "remote"}}
+        ext_net_bank_mock = Mock()
+        question_bank.return_value = ext_net_bank_mock
+        ext_net_bank_mock.nic.ask.return_value = "eth12"
+        step = configure.SetLocalHypervisorOptions("maas0.local", jhelper)
+        step.prompt()
+        assert step.nic == "eth12"
+
+    def test_prompt_local(self, cclient, jhelper, load_answers, question_bank):
+        load_answers.return_value = {"user": {"remote_access_location": "local"}}
+        ext_net_bank_mock = Mock()
+        question_bank.return_value = ext_net_bank_mock
+        ext_net_bank_mock.nic.ask.return_value = "eth12"
+        step = configure.SetLocalHypervisorOptions("maas0.local", jhelper)
+        step.prompt()
+        assert step.nic is None
+
+    def test_run(self, cclient, jhelper):
+        jhelper.run_action.return_value = {"return-code": 0}
+        unit_mock = Mock()
+        unit_mock.entity_id = "openstack-hypervisor/0"
+        jhelper.get_unit_from_machine.return_value = unit_mock
+        step = configure.SetLocalHypervisorOptions("maas0.local", jhelper)
+        step.nic = "eth11"
+        result = step.run()
+        jhelper.run_action.assert_called_once_with(
+            "openstack-hypervisor/0",
+            "controller",
+            "set-hypervisor-local-settings",
+            action_params={"external-nic": "eth11"},
+        )
+        assert result.result_type == ResultType.COMPLETED
+
+    def test_run_fail(self, cclient, jhelper):
+        jhelper.run_action.return_value = {"return-code": 2}
+        jhelper.get_leader_unit.return_value = "openstack-hypervisor/0"
+        step = configure.SetLocalHypervisorOptions("maas0.local", jhelper)
+        step.nic = "eth11"
+        with pytest.raises(
+            click.ClickException, match="Unable to set local hypervisor config"
+        ):
+            step.run()
+
+    def test_run_skipped(self, cclient, jhelper):
+        step = configure.SetLocalHypervisorOptions("maas0.local", jhelper)
+        step.nic = None
+        step.run()
+        assert not jhelper.run_action.called

--- a/tests/unit/sunbeam/commands/test_configure.py
+++ b/tests/unit/sunbeam/commands/test_configure.py
@@ -17,7 +17,6 @@ import json
 from pathlib import Path
 from unittest.mock import AsyncMock, Mock, patch
 
-import click
 import pytest
 
 import sunbeam.commands.configure as configure
@@ -374,10 +373,8 @@ class TestSetLocalHypervisorOptions:
         jhelper.get_leader_unit.return_value = "openstack-hypervisor/0"
         step = configure.SetLocalHypervisorOptions("maas0.local", jhelper)
         step.nic = "eth11"
-        with pytest.raises(
-            click.ClickException, match="Unable to set local hypervisor config"
-        ):
-            step.run()
+        result = step.run()
+        assert result.result_type == ResultType.FAILED
 
     def test_run_skipped(self, cclient, jhelper):
         step = configure.SetLocalHypervisorOptions("maas0.local", jhelper)


### PR DESCRIPTION
This change adds a configure step that can be run after bootstrap. The configure step will optionally setup default images, flavors etc in the cloud as well as configuring networking.

The last step in the plan configure executes runs an action on the openstack-hypervisor charm to set unit specific values such as which nic to use for North/South traffic. This change also adds that step to the node join command.

Depends-On: https://review.opendev.org/c/openstack/charm-openstack-hypervisor/+/881493