### PR TITLE
Add pre-flight check for $HOME/.local/share

### DIFF
--- a/sunbeam/commands/bootstrap.py
+++ b/sunbeam/commands/bootstrap.py
@@ -45,7 +45,12 @@ from sunbeam.commands.microk8s import (
 )
 from sunbeam.commands.openstack import DeployControlPlaneStep
 from sunbeam.commands.terraform import TerraformHelper, TerraformInitStep
-from sunbeam.jobs.checks import DaemonGroupCheck, JujuSnapCheck, SshKeysConnectedCheck
+from sunbeam.jobs.checks import (
+    DaemonGroupCheck,
+    JujuSnapCheck,
+    LocalShareCheck,
+    SshKeysConnectedCheck,
+)
 from sunbeam.jobs.common import Role, get_step_message, run_plan, run_preflight_checks
 from sunbeam.jobs.juju import CONTROLLER, JujuHelper
 
@@ -92,6 +97,7 @@ def bootstrap(role: str) -> None:
     preflight_checks.append(JujuSnapCheck())
     preflight_checks.append(SshKeysConnectedCheck())
     preflight_checks.append(DaemonGroupCheck())
+    preflight_checks.append(LocalShareCheck())
 
     run_preflight_checks(preflight_checks, console)
 

--- a/sunbeam/commands/configure.py
+++ b/sunbeam/commands/configure.py
@@ -26,22 +26,22 @@ import click
 from rich.console import Console
 from snaphelpers import Snap
 
-from sunbeam.clusterd.client import Client
 import sunbeam.jobs.questions
 from sunbeam import utils
-from sunbeam.jobs.juju import (
-    JujuHelper,
-    ModelNotFoundException,
-    run_sync,
-    CONTROLLER_MODEL,
-)
+from sunbeam.clusterd.client import Client
+from sunbeam.commands.openstack import OPENSTACK_MODEL
 from sunbeam.commands.terraform import (
     TerraformException,
     TerraformHelper,
     TerraformInitStep,
 )
 from sunbeam.jobs.common import BaseStep, Result, ResultType, Status, run_plan
-from sunbeam.commands.openstack import OPENSTACK_MODEL
+from sunbeam.jobs.juju import (
+    CONTROLLER_MODEL,
+    JujuHelper,
+    ModelNotFoundException,
+    run_sync,
+)
 
 CLOUD_CONFIG_SECTION = "CloudConfig"
 LOG = logging.getLogger(__name__)

--- a/sunbeam/commands/node.py
+++ b/sunbeam/commands/node.py
@@ -28,9 +28,7 @@ from sunbeam.commands.clusterd import (
     ClusterRemoveNodeStep,
     ClusterUpdateNodeStep,
 )
-from sunbeam.commands.configure import (
-    SetLocalHypervisorOptions,
-)
+from sunbeam.commands.configure import SetLocalHypervisorOptions
 from sunbeam.commands.hypervisor import AddHypervisorUnitStep
 from sunbeam.commands.juju import AddJujuMachineStep  # RemoveJujuUserStep,
 from sunbeam.commands.juju import (
@@ -40,7 +38,12 @@ from sunbeam.commands.juju import (
     SaveJujuUserLocallyStep,
 )
 from sunbeam.commands.microk8s import AddMicrok8sUnitStep, RemoveMicrok8sUnitStep
-from sunbeam.jobs.checks import DaemonGroupCheck, JujuSnapCheck, SshKeysConnectedCheck
+from sunbeam.jobs.checks import (
+    DaemonGroupCheck,
+    JujuSnapCheck,
+    LocalShareCheck,
+    SshKeysConnectedCheck,
+)
 from sunbeam.jobs.common import (
     ResultType,
     Role,
@@ -106,6 +109,7 @@ def join(token: str, role: str) -> None:
     preflight_checks.append(JujuSnapCheck())
     preflight_checks.append(SshKeysConnectedCheck())
     preflight_checks.append(DaemonGroupCheck())
+    preflight_checks.append(LocalShareCheck())
 
     run_preflight_checks(preflight_checks, console)
 

--- a/sunbeam/jobs/checks.py
+++ b/sunbeam/jobs/checks.py
@@ -88,8 +88,11 @@ class SshKeysConnectedCheck(Check):
 
         if not snap_ctl.is_connected("ssh-keys"):
             self.message = (
-                "ssh-keys interface not detected: please connect ssh-keys interface "
-                f"by running {connect!r}"
+                "ssh-keys interface not detected\n"
+                "Please connect ssh-keys interface by running:\n"
+                "\n"
+                f"    {connect}"
+                "\n"
             )
             return False
 
@@ -123,6 +126,34 @@ class DaemonGroupCheck(Check):
                 f" running 'newgrp {self.group}'."
             )
 
+            return False
+
+        return True
+
+
+# NOTE: drop with Juju can do this itself
+class LocalShareCheck(Check):
+    """Check if ~/.local/share exists for Juju use."""
+
+    def __init__(self):
+        super().__init__(
+            "Check for .local/share directory",
+            "Checking for ~/.local/share directory for Juju",
+        )
+
+    def run(self) -> bool:
+        """Check for ~./local/share."""
+        snap = Snap()
+
+        local_share = snap.paths.real_home / ".local" / "share"
+        if not os.path.exists(local_share):
+            self.message = (
+                f"{local_share} directory not detected\n"
+                "Please create by running:\n"
+                "\n"
+                f"    mkdir -p {local_share}"
+                "\n"
+            )
             return False
 
         return True

--- a/tests/unit/sunbeam/commands/test_configure.py
+++ b/tests/unit/sunbeam/commands/test_configure.py
@@ -74,6 +74,13 @@ def thelper():
     yield Mock(path=Path())
 
 
+@pytest.fixture()
+def get_nic_macs():
+    with patch.object(sunbeam.utils, "get_nic_macs") as p:
+        p.return_value = ["00:16:3e:01:6e:75"]
+        yield p
+
+
 class SetHypervisorCharmConfigStep:
     def test_is_skip(self, cclient, jhelper):
         step = configure.SetHypervisorCharmConfigStep(jhelper, "/tmp/dummypath")
@@ -167,7 +174,7 @@ class TestUserQuestions:
         return user_bank_mock, net_bank_mock
 
     def test_prompt_remote_demo_setup(
-        self, cclient, load_answers, question_bank, write_answers
+        self, cclient, load_answers, question_bank, write_answers, get_nic_macs
     ):
         load_answers.return_value = {}
         user_bank_mock, net_bank_mock = self.configure_mocks(question_bank)
@@ -179,7 +186,7 @@ class TestUserQuestions:
         self.check_remote_questions(net_bank_mock)
 
     def test_prompt_remote_no_demo_setup(
-        self, cclient, load_answers, question_bank, write_answers
+        self, cclient, load_answers, question_bank, write_answers, get_nic_macs
     ):
         load_answers.return_value = {}
         user_bank_mock, net_bank_mock = self.configure_mocks(question_bank)
@@ -312,7 +319,9 @@ class TestSetLocalHypervisorOptions:
         step = configure.SetLocalHypervisorOptions("maas0.local", jhelper)
         assert step.has_prompts()
 
-    def test_prompt_remote(self, cclient, jhelper, load_answers, question_bank):
+    def test_prompt_remote(
+        self, cclient, jhelper, load_answers, question_bank, get_nic_macs
+    ):
         load_answers.return_value = {"user": {"remote_access_location": "remote"}}
         ext_net_bank_mock = Mock()
         question_bank.return_value = ext_net_bank_mock
@@ -321,7 +330,9 @@ class TestSetLocalHypervisorOptions:
         step.prompt()
         assert step.nic == "eth12"
 
-    def test_prompt_remote_join(self, cclient, jhelper, load_answers, question_bank):
+    def test_prompt_remote_join(
+        self, cclient, jhelper, load_answers, question_bank, get_nic_macs
+    ):
         load_answers.return_value = {"user": {"remote_access_location": "remote"}}
         ext_net_bank_mock = Mock()
         question_bank.return_value = ext_net_bank_mock
@@ -341,7 +352,9 @@ class TestSetLocalHypervisorOptions:
         step.prompt()
         assert step.nic is None
 
-    def test_prompt_local_join(self, cclient, jhelper, load_answers, question_bank):
+    def test_prompt_local_join(
+        self, cclient, jhelper, load_answers, question_bank, get_nic_macs
+    ):
         load_answers.return_value = {"user": {"remote_access_location": "local"}}
         ext_net_bank_mock = Mock()
         question_bank.return_value = ext_net_bank_mock

--- a/tests/unit/sunbeam/jobs/test_checks.py
+++ b/tests/unit/sunbeam/jobs/test_checks.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import os
+from pathlib import PosixPath
 from unittest.mock import Mock
 
 from sunbeam.jobs import checks
@@ -65,3 +66,28 @@ class TestDaemonGroupCheck:
 
         assert result is False
         assert "Insufficient permissions" in check.message
+
+
+class TestLocalShareCheck:
+    def test_run(self, mocker, snap):
+        mocker.patch.object(checks, "Snap", return_value=snap)
+        mocker.patch("os.path.exists", return_value=True)
+
+        check = checks.LocalShareCheck()
+
+        result = check.run()
+
+        assert result is True
+        os.path.exists.assert_called_with(PosixPath("/home/ubuntu/.local/share"))
+
+    def test_run_missing(self, mocker, snap):
+        mocker.patch.object(checks, "Snap", return_value=snap)
+        mocker.patch("os.path.exists", return_value=False)
+
+        check = checks.LocalShareCheck()
+
+        result = check.run()
+
+        assert result is False
+        assert "directory not detected" in check.message
+        os.path.exists.assert_called_with(PosixPath("/home/ubuntu/.local/share"))


### PR DESCRIPTION
Juju commands will fail unless the parent directories for $HOME/.local/share/juju exist - check that they are present before bootstrap or join commands.

Fix isolation of tests to ensure that odd interface types don't break tests.