### PR TITLE
Pin urrllib3<2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ rich # MIT
 # Used for communication with snapd socket
 requests # Apache 2
 requests-unixsocket # Apache 2
+urllib3<2 # https://github.com/psf/requests/issues/6432
 
 # Used for getting local ip address
 netifaces


### PR DESCRIPTION
requests 2.29.0 breaks with urllib3>=2 [1]
Pin urllib3 to <2

[1] https://github.com/psf/requests/issues/6432