### PR TITLE
check for hypervisor app in join command

### DIFF
--- a/sunbeam/commands/bootstrap.py
+++ b/sunbeam/commands/bootstrap.py
@@ -108,12 +108,12 @@ def bootstrap(
     data_location = snap.paths.user_data
 
     # NOTE: install to user writable location
-    for tfplan_dir in [
-        "deploy-microk8s",
-        "deploy-microceph",
-        "deploy-openstack",
-        "deploy-openstack-hypervisor",
-    ]:
+    tfplan_dirs = []
+    if is_control_node:
+        tfplan_dirs.extend(["deploy-microk8s", "deploy-microceph", "deploy-openstack"])
+    if is_compute_node:
+        tfplan_dirs.extend(["deploy-openstack-hypervisor"])
+    for tfplan_dir in tfplan_dirs:
         src = snap.paths.snap / "etc" / tfplan_dir
         dst = snap.paths.user_common / "etc" / tfplan_dir
         LOG.debug(f"Updating {dst} from {src}...")

--- a/sunbeam/commands/hypervisor.py
+++ b/sunbeam/commands/hypervisor.py
@@ -59,6 +59,19 @@ class DeployHypervisorApplicationStep(BaseStep, JujuStepHelper):
         self.hypervisor_model = CONTROLLER_MODEL.split("/")[-1]
         self.openstack_model = OPENSTACK_MODEL
 
+    def is_skip(self, status: Optional[Status] = None) -> Result:
+        """Determines if the step should be skipped or not.
+
+        :return: ResultType.SKIPPED if the Step should be skipped,
+                ResultType.COMPLETED or ResultType.FAILED otherwise
+        """
+        try:
+            run_sync(self.jhelper.get_application(APPLICATION, MODEL))
+        except ApplicationNotFoundException:
+            return Result(ResultType.COMPLETED)
+
+        return Result(ResultType.SKIPPED)
+
     def run(self, status: Optional[Status] = None) -> Result:
         """Apply terraform configuration to deploy hypervisor"""
         machine_ids = []

--- a/tests/unit/sunbeam/commands/test_hypervisor.py
+++ b/tests/unit/sunbeam/commands/test_hypervisor.py
@@ -58,6 +58,24 @@ class TestDeployHypervisorStep(unittest.TestCase):
     def tearDown(self):
         self.client.stop()
 
+    def test_is_skip(self):
+        self.jhelper.get_application.side_effect = ApplicationNotFoundException(
+            "not found"
+        )
+
+        step = DeployHypervisorApplicationStep(self.tfhelper, self.jhelper)
+        result = step.is_skip()
+
+        self.jhelper.get_application.assert_called_once()
+        assert result.result_type == ResultType.COMPLETED
+
+    def test_is_skip_app_already_deployed(self):
+        step = DeployHypervisorApplicationStep(self.tfhelper, self.jhelper)
+        result = step.is_skip()
+
+        self.jhelper.get_application.assert_called_once()
+        assert result.result_type == ResultType.SKIPPED
+
     def test_run_pristine_installation(self):
         self.jhelper.get_application.side_effect = ApplicationNotFoundException(
             "not found"


### PR DESCRIPTION
Currently hypervisor app is deployed only in
bootstrap command. However if role compute is
not defined during bootstrap, hypervisor app
is never deployed.
Execute DeployHypervisorApp plan as part of
join command as well. Update is_skip function
to skip deploying app if already exists.