### PR TITLE
Fix terraform ordering of microceph plan

### DIFF
--- a/cloud/etc/deploy-microceph/main.tf
+++ b/cloud/etc/deploy-microceph/main.tf
@@ -49,7 +49,7 @@ resource "juju_application" "microceph" {
 
 # juju_offer.microceph_offer will be created
 resource "juju_offer" "microceph_offer" {
-   application_name = "microceph"
-   endpoint         = "ceph"
-   model            = data.juju_model.controller.name
+  application_name = juju_application.microceph.name
+  endpoint         = "ceph"
+  model            = data.juju_model.controller.name
 }


### PR DESCRIPTION
Terraform tries to create the offer before the application when deploying with `-parallelism 1`. Adding reference to `juju_application.microceph` adds ordering context to terraform dependency engine.