### PR TITLE
Implement control plane resizing

### DIFF
--- a/sunbeam/commands/bootstrap.py
+++ b/sunbeam/commands/bootstrap.py
@@ -64,6 +64,7 @@ from sunbeam.jobs.common import (
     run_plan,
     run_preflight_checks,
     validate_roles,
+    click_option_topology,
 )
 from sunbeam.jobs.juju import CONTROLLER, JujuHelper
 
@@ -84,8 +85,31 @@ snap = Snap()
     help="Specify whether the node will be a control node, a "
     "compute node or a storage node. Defaults to all the roles.",
 )
+@click_option_topology
+@click.option(
+    "--database",
+    default="auto",
+    type=click.Choice(
+        [
+            "auto",
+            "single",
+            "multi",
+        ],
+        case_sensitive=False,
+    ),
+    help=(
+        "Allows definition of the intended cluster configuration: "
+        "'auto' for automatic determination, "
+        "'single' for a single database, "
+        "'multi' for a database per service, "
+    ),
+)
 def bootstrap(
-    role: List[Role], preseed: Optional[Path] = None, accept_defaults: bool = False
+    role: List[Role],
+    topology: str,
+    database: str,
+    preseed: Optional[Path] = None,
+    accept_defaults: bool = False,
 ) -> None:
     """Bootstrap the local node.
 
@@ -195,7 +219,11 @@ def bootstrap(
 
     if is_control_node:
         plan4.append(TerraformInitStep(tfhelper_openstack_deploy))
-        plan4.append(DeployControlPlaneStep(tfhelper_openstack_deploy, jhelper))
+        plan4.append(
+            DeployControlPlaneStep(
+                tfhelper_openstack_deploy, jhelper, topology, database
+            )
+        )
 
     run_plan(plan4, console)
 

--- a/sunbeam/commands/resize.py
+++ b/sunbeam/commands/resize.py
@@ -1,0 +1,65 @@
+# Copyright (c) 2023 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+import shutil
+
+import click
+from rich.console import Console
+from snaphelpers import Snap
+
+from sunbeam.commands.openstack import ResizeControlPlaneStep
+from sunbeam.commands.terraform import TerraformHelper, TerraformInitStep
+from sunbeam.jobs.common import (
+    run_plan,
+    click_option_topology,
+)
+from sunbeam.jobs.juju import JujuHelper
+
+LOG = logging.getLogger(__name__)
+console = Console()
+snap = Snap()
+
+
+@click.command()
+@click_option_topology
+@click.option(
+    "-f", "--force", help="Force resizing to incompatible topology.", is_flag=True
+)
+def resize(topology: str, force: bool = False) -> None:
+    """Expand the control plane to fit available nodes."""
+
+    tfplan = "deploy-openstack"
+    src = snap.paths.snap / "etc" / tfplan
+    dst = snap.paths.user_common / "etc" / tfplan
+    LOG.debug(f"Updating {dst} from {src}...")
+    shutil.copytree(src, dst, dirs_exist_ok=True)
+
+    data_location = snap.paths.user_data
+    tfhelper = TerraformHelper(
+        path=snap.paths.user_common / "etc" / tfplan,
+        plan="openstack-plan",
+        parallelism=1,
+        backend="http",
+        data_location=data_location,
+    )
+    jhelper = JujuHelper(data_location)
+    plan = [
+        TerraformInitStep(tfhelper),
+        ResizeControlPlaneStep(tfhelper, jhelper, topology, force),
+    ]
+
+    run_plan(plan, console)
+
+    click.echo("Resize complete.")

--- a/sunbeam/jobs/common.py
+++ b/sunbeam/jobs/common.py
@@ -18,8 +18,10 @@ import logging
 from typing import List, Optional, Type
 
 import click
+from click import decorators
 from rich.console import Console
 from rich.status import Status
+
 
 LOG = logging.getLogger(__name__)
 
@@ -258,3 +260,35 @@ def validate_roles(
         return [Role[role.upper()] for role in value]
     except KeyError as e:
         raise click.BadParameter(str(e))
+
+
+def get_host_total_ram() -> int:
+    """Reads meminfo to get total ram in KB."""
+    with open("/proc/meminfo") as f:
+        for line in f:
+            if line.startswith("MemTotal"):
+                return int(line.split()[1])
+    raise Exception("Could not determine total RAM")
+
+
+def click_option_topology(func: decorators.FC) -> decorators.FC:
+    return click.option(
+        "--topology",
+        default="auto",
+        type=click.Choice(
+            [
+                "auto",
+                "single",
+                "multi",
+                "large",
+            ],
+            case_sensitive=False,
+        ),
+        help=(
+            "Allows definition of the intended cluster configuration: "
+            "'auto' for automatic determination, "
+            "'single' for a single-node cluster, "
+            "'multi' for a multi-node cluster, "
+            "'large' for a large scale cluster"
+        ),
+    )(func)

--- a/sunbeam/jobs/juju.py
+++ b/sunbeam/jobs/juju.py
@@ -531,7 +531,9 @@ class JujuHelper:
 
         try:
             # Wait for all the unit workload status to active and Agent status to idle
-            await model_impl.wait_for_idle(apps=apps, status="active", timeout=timeout)
+            await model_impl.wait_for_idle(
+                apps=apps, status="active", timeout=timeout, raise_on_error=False
+            )
         except (JujuMachineError, JujuAgentError, JujuUnitError, JujuAppError) as e:
             raise JujuWaitException(
                 f"Error while waiting for model {model!r} to be ready: {str(e)}"

--- a/sunbeam/main.py
+++ b/sunbeam/main.py
@@ -23,6 +23,7 @@ from sunbeam.commands import configure as configure_cmds
 from sunbeam.commands import node as node_cmds
 from sunbeam.commands import openrc as openrc_cmds
 from sunbeam.commands import prepare_node as prepare_node_cmds
+from sunbeam.commands import resize as resize_cmds
 
 LOG = logging.getLogger()
 
@@ -60,6 +61,7 @@ def main():
     cluster.add_command(node_cmds.join)
     cluster.add_command(node_cmds.list)
     cluster.add_command(node_cmds.remove)
+    cluster.add_command(resize_cmds.resize)
     cli.add_command(openrc_cmds.openrc)
     cli()
 


### PR DESCRIPTION
* Add `--topology` option to bootstrap, specify intented size of cluster, can be changed with `resize` command
* Add `--database` option to bootstrap, specify which database architecture to deploy: single mysql or many mysql. Cannot be changed later
* Add `resize` command to enable resizing the control plane during cluster lifetime.