### PR TITLE
Perform validation when prompting user for a nic

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ urllib3<2 # https://github.com/psf/requests/issues/6432
 
 # Used for getting local ip address
 netifaces
+pyroute2
 
 # Generation of user passwords
 pwgen

--- a/sunbeam/commands/bootstrap.py
+++ b/sunbeam/commands/bootstrap.py
@@ -60,11 +60,11 @@ from sunbeam.jobs.checks import (
 )
 from sunbeam.jobs.common import (
     Role,
+    click_option_topology,
     get_step_message,
     run_plan,
     run_preflight_checks,
     validate_roles,
-    click_option_topology,
 )
 from sunbeam.jobs.juju import CONTROLLER, JujuHelper
 

--- a/sunbeam/commands/configure.py
+++ b/sunbeam/commands/configure.py
@@ -171,7 +171,7 @@ def ext_net_questions():
             "VLAN ID to use for external network", default_value=0
         ),
         "nic": NicQuestion(
-            "Free network interface microstack can use for external traffic"
+            "Free network interface that will be configured for external traffic"
         ),
     }
 
@@ -577,7 +577,7 @@ class TerraformDemoInitStep(TerraformInitStep):
 
 class SetLocalHypervisorOptions(BaseStep):
     def __init__(
-        self, name, jhelper, join_mode: bool = False, preseed_file: str = None
+        self, name, jhelper, join_mode: bool = False, preseed_file: Path = None
     ):
         super().__init__(
             "Apply local hypervisor settings", "Apply local hypervisor settings"
@@ -602,7 +602,7 @@ class SetLocalHypervisorOptions(BaseStep):
             "remote_access_location"
         )
         if self.preseed_file:
-            preseed = sunbeam.jobs.questions.read_preseed(Path(self.preseed_file))
+            preseed = sunbeam.jobs.questions.read_preseed(self.preseed_file)
         else:
             preseed = {}
         # If adding new nodes to the cluster then local access makes no sense

--- a/sunbeam/commands/openstack.py
+++ b/sunbeam/commands/openstack.py
@@ -28,12 +28,7 @@ from sunbeam.commands.microk8s import (
     MICROK8S_DEFAULT_STORAGECLASS,
 )
 from sunbeam.commands.terraform import TerraformException, TerraformHelper
-from sunbeam.jobs.common import (
-    BaseStep,
-    Result,
-    ResultType,
-    get_host_total_ram,
-)
+from sunbeam.jobs.common import BaseStep, Result, ResultType, get_host_total_ram
 from sunbeam.jobs.juju import (
     CONTROLLER_MODEL,
     JujuHelper,

--- a/sunbeam/commands/resize.py
+++ b/sunbeam/commands/resize.py
@@ -21,10 +21,7 @@ from snaphelpers import Snap
 
 from sunbeam.commands.openstack import ResizeControlPlaneStep
 from sunbeam.commands.terraform import TerraformHelper, TerraformInitStep
-from sunbeam.jobs.common import (
-    run_plan,
-    click_option_topology,
-)
+from sunbeam.jobs.common import click_option_topology, run_plan
 from sunbeam.jobs.juju import JujuHelper
 
 LOG = logging.getLogger(__name__)

--- a/sunbeam/jobs/common.py
+++ b/sunbeam/jobs/common.py
@@ -22,7 +22,6 @@ from click import decorators
 from rich.console import Console
 from rich.status import Status
 
-
 LOG = logging.getLogger(__name__)
 
 

--- a/sunbeam/jobs/questions.py
+++ b/sunbeam/jobs/questions.py
@@ -20,7 +20,7 @@ from typing import Any, Callable, Optional
 
 import yaml
 from rich.console import Console
-from rich.prompt import Confirm, Prompt, DefaultType, Text
+from rich.prompt import Confirm, DefaultType, Prompt, Text
 
 from sunbeam.clusterd.client import Client
 from sunbeam.clusterd.service import ConfigItemNotFoundException

--- a/tests/unit/sunbeam/test_utils.py
+++ b/tests/unit/sunbeam/test_utils.py
@@ -1,0 +1,128 @@
+# Copyright 2023 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+import sunbeam.utils as utils
+
+
+@pytest.fixture()
+def ifaddresses():
+    with patch("sunbeam.utils.netifaces.ifaddresses") as p:
+        p.return_value = {
+            17: [{"addr": "00:16:3e:07:ba:1e", "broadcast": "ff:ff:ff:ff:ff:ff"}],
+            2: [
+                {
+                    "addr": "10.177.200.93",
+                    "netmask": "255.255.255.0",
+                    "broadcast": "10.177.200.255",
+                }
+            ],
+            10: [
+                {
+                    "addr": "fe80::216:3eff:fe07:ba1e%enp5s0",
+                    "netmask": "ffff:ffff:ffff:ffff::/64",
+                }
+            ],
+        }
+        yield p
+
+
+class TestUtils:
+    def test_is_nic_connected(self, mocker):
+        context_manager = mocker.patch("sunbeam.utils.IPDB")
+        mock_eth3 = Mock()
+        mock_eth3.operstate = "DOWN"
+        mock_eth4 = Mock()
+        mock_eth4.operstate = "UP"
+        context_manager.return_value.__enter__.return_value.interfaces = {
+            "eth3": mock_eth3,
+            "eth4": mock_eth4,
+        }
+        assert utils.is_nic_connected("eth4")
+        assert not utils.is_nic_connected("eth3")
+
+    def test_is_nic_up(self, mocker):
+        context_manager = mocker.patch("sunbeam.utils.NDB")
+        context_manager.return_value.__enter__.return_value.interfaces = {
+            "eth3": {"state": "DOWN"},
+            "eth4": {"state": "UP"},
+        }
+        assert utils.is_nic_up("eth4")
+        assert not utils.is_nic_up("eth3")
+
+    def test_get_fqdn(self, mocker):
+        getfqdn = mocker.patch("sunbeam.utils.socket.getfqdn")
+        getfqdn.return_value = "myhost.local"
+        assert utils.get_fqdn() == "myhost.local"
+
+    def test_get_local_ip_by_default_route(self, mocker, ifaddresses):
+        gateways = mocker.patch("sunbeam.utils.netifaces.gateways")
+        gateways.return_value = {"default": {2: ("10.177.200.1", "enp5s0")}}
+        assert utils.get_local_ip_by_default_route() == "10.177.200.93"
+
+    def test_get_nic_macs(self, ifaddresses):
+        assert utils.get_nic_macs("eth1") == ["00:16:3e:07:ba:1e"]
+
+    def test_get_free_nics(self, mocker):
+        glob = mocker.patch("sunbeam.utils.glob.glob")
+        glob.side_effect = lambda x: {
+            "/sys/devices/virtual/net/*": [
+                "/sys/devices/virtual/net/lo",
+                "/sys/devices/virtual/net/vxlan.calico",
+            ],
+            "/proc/net/bonding/*": [
+                "/proc/net/bonding/bond0",
+                "/proc/net/bonding/bond1",
+            ],
+        }[x]
+        get_nic_macs = mocker.patch("sunbeam.utils.get_nic_macs")
+        get_nic_macs.side_effect = lambda x: {
+            "lo": ["lomac1"],
+            "eth0": ["mac0"],
+            "eth1": ["mac3"],
+            "eth2": ["mac4"],
+            "vxlan.calico": ["vcmac1"],
+            "bond0": ["mac1", "mac2"],
+            "bond1": ["mac3", "mac4"],
+        }[x]
+        is_configured = mocker.patch("sunbeam.utils.is_configured")
+        is_configured.side_effect = lambda x: {
+            "lo": True,
+            "eth0": False,
+            "bond0": True,
+            "bond1": False,
+        }[x]
+        interfaces = mocker.patch("sunbeam.utils.netifaces.interfaces")
+        interfaces.return_value = [
+            "lo",
+            "vxlan.calico",
+            "bond0",
+            "bond1",
+            "eth0",
+            "eth1",
+        ]
+        assert utils.get_free_nics() == ["bond1", "eth0"]
+
+    def test_get_free_nic(self, mocker):
+        get_free_nics = mocker.patch("sunbeam.utils.get_free_nics")
+        get_free_nics.return_value = ["eth0", "eth1", "eth2"]
+        assert utils.get_free_nic() == "eth0"
+
+    def test_generate_password(self, mocker):
+        generate_password = mocker.patch("sunbeam.utils.generate_password")
+        generate_password.return_value = "abcdefghijkl"
+        assert utils.generate_password() == "abcdefghijkl"


### PR DESCRIPTION
Update the question that asks the user to provide a nic so that it checks the state of the nic and reports to the user if anything is wrong (nic down, not connected etc). This includes these design decisions:

   * The question does not respect the --accept-defaults flag.
   * The question does respect the --preseed flag.
   * The prompt suggests a list of possible nics to choose from, this list is a list of unconfigured nics on the machine. The user does not have to select from this list but if a nic is not on the list it will fail validation and the user will be prompted again.