### PR TITLE
Fix app status checks for removing units

### DIFF
--- a/sunbeam/commands/hypervisor.py
+++ b/sunbeam/commands/hypervisor.py
@@ -217,7 +217,10 @@ class RemoveHypervisorUnitStep(BaseStep, JujuStepHelper):
             run_sync(self.jhelper.remove_unit(APPLICATION, str(self.unit), MODEL))
             run_sync(
                 self.jhelper.wait_application_ready(
-                    APPLICATION, MODEL, timeout=HYPERVISOR_UNIT_TIMEOUT
+                    APPLICATION,
+                    MODEL,
+                    accepted_status=["active", "unknown"],
+                    timeout=HYPERVISOR_UNIT_TIMEOUT,
                 )
             )
         except (ApplicationNotFoundException, TimeoutException) as e:

--- a/sunbeam/commands/microceph.py
+++ b/sunbeam/commands/microceph.py
@@ -203,7 +203,10 @@ class RemoveMicrocephUnitStep(BaseStep):
             run_sync(self.jhelper.remove_unit(APPLICATION, str(self.unit), MODEL))
             run_sync(
                 self.jhelper.wait_application_ready(
-                    APPLICATION, MODEL, timeout=MICROCEPH_UNIT_TIMEOUT
+                    APPLICATION,
+                    MODEL,
+                    accepted_status=["active", "unknown"],
+                    timeout=MICROCEPH_UNIT_TIMEOUT,
                 )
             )
         except (ApplicationNotFoundException, TimeoutException) as e:

--- a/sunbeam/commands/microk8s.py
+++ b/sunbeam/commands/microk8s.py
@@ -254,7 +254,10 @@ class RemoveMicrok8sUnitStep(BaseStep, JujuStepHelper):
             run_sync(self.jhelper.remove_unit(APPLICATION, str(self.unit), MODEL))
             run_sync(
                 self.jhelper.wait_application_ready(
-                    APPLICATION, MODEL, timeout=MICROK8S_UNIT_TIMEOUT
+                    APPLICATION,
+                    MODEL,
+                    accepted_status=["active", "unknown"],
+                    timeout=MICROK8S_UNIT_TIMEOUT,
                 )
             )
         except (ApplicationNotFoundException, TimeoutException) as e:


### PR DESCRIPTION
While removing the last unit, the application status is unknown. So change the conditition to check for application status to active and unknown while
removing a unit.
This is applicable for microk8s, microceph and
hypervisor.