### PR TITLE
Use --no-prompt option for remove machine

### DIFF
--- a/sunbeam/commands/juju.py
+++ b/sunbeam/commands/juju.py
@@ -617,6 +617,7 @@ class RemoveJujuMachineStep(BaseStep, JujuStepHelper):
                 "-m",
                 CONTROLLER_MODEL,
                 str(self.machine_id),
+                "--no-prompt",
             ]
             LOG.debug(f'Running command {" ".join(cmd)}')
             process = subprocess.run(cmd, capture_output=True, text=True, check=True)


### PR DESCRIPTION
Currently juju remove-machine asks for
confirmation whether to remove machine
or not. Use --no-prompt to make the
remove-machine non-interactive.