### PR TITLE
Update cluster list output to tabular format

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,9 @@ git+https://github.com/albertodonato/snap-helpers#egg=snap-helpers # LGPLv3
 click>=8.1.3 # BSD
 rich # MIT
 
+# used for pretty printing of tables
+prettytable
+
 # Used for communication with snapd socket
 requests # Apache 2
 requests-unixsocket # Apache 2

--- a/sunbeam/commands/clusterd.py
+++ b/sunbeam/commands/clusterd.py
@@ -185,11 +185,21 @@ class ClusterListNodeStep(BaseStep):
         self.client = clusterClient()
 
     def run(self, status: Optional[Status] = None) -> Result:
-        """Join node to sunbeam cluster"""
+        """List nodes in the sunbeam cluster"""
         try:
             members = self.client.cluster.get_cluster_members()
-            LOG.info(members)
-            return Result(result_type=ResultType.COMPLETED, message=members)
+            LOG.debug(f"Members: {members}")
+            nodes = self.client.cluster.list_nodes()
+            LOG.debug(f"Nodes: {nodes}")
+
+            nodes_dict = {
+                member.get("name"): {"status": member.get("status")}
+                for member in members
+            }
+            for node in nodes:
+                nodes_dict[node.get("name")].update({"role": node.get("role")})
+
+            return Result(result_type=ResultType.COMPLETED, message=nodes_dict)
         except ClusterServiceUnavailableException as e:
             LOG.warning(e)
             return Result(ResultType.FAILED, str(e))

--- a/sunbeam/commands/node.py
+++ b/sunbeam/commands/node.py
@@ -18,6 +18,7 @@ import shutil
 from typing import List
 
 import click
+from prettytable import PrettyTable
 from rich.console import Console
 from snaphelpers import Snap
 
@@ -218,9 +219,26 @@ def list() -> None:
     results = run_plan(plan, console)
 
     list_node_step_result = results.get("ClusterListNodeStep")
+    nodes = list_node_step_result.message
+
+    table = PrettyTable()
+    table.field_names = ["Node", "Status", "Control", "Compute", "Storage"]
+    table_data = []
+    for name, node in nodes.items():
+        table_data.append(
+            [
+                name,
+                "Up" if node.get("status") == "ONLINE" else "Down",
+                "X" if "CONTROL" in node.get("role", "") else "",
+                "X" if "COMPUTE" in node.get("role", "") else "",
+                "X" if "STORAGE" in node.get("role", "") else "",
+            ]
+        )
+    if table_data:
+        table.add_rows(table_data)
 
     click.echo("Sunbeam Cluster Node List:")
-    click.echo(f"{list_node_step_result.message}")
+    click.echo(table)
 
 
 @click.command()


### PR DESCRIPTION
Currently cluster list command outputs the
cluster members from cluster daemon. Add node
roles to the output and present in tabular
format.