### PR TITLE
Add upgrade option to terraform init

### DIFF
--- a/cloud/etc/deploy-microk8s/main.tf
+++ b/cloud/etc/deploy-microk8s/main.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.6.0"
+      version = ">= 0.7.0"
     }
   }
 

--- a/cloud/etc/deploy-openstack-hypervisor/main.tf
+++ b/cloud/etc/deploy-openstack-hypervisor/main.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.6.0"
+      version = ">= 0.7.0"
     }
   }
 

--- a/sunbeam/commands/terraform.py
+++ b/sunbeam/commands/terraform.py
@@ -132,7 +132,7 @@ class TerraformHelper:
             os_env.update(self.update_juju_provider_credentials())
 
         try:
-            cmd = [self.terraform, "init", "-no-color"]
+            cmd = [self.terraform, "init", "-upgrade", "-no-color"]
             LOG.debug(f'Running command {" ".join(cmd)}')
             process = subprocess.run(
                 cmd,


### PR DESCRIPTION
Any updates to terraform plugin versions will
error out. Add -upgrade option to terraform
init command so that the plugins will be
updated to newer version.
Update juju provider plugin to 0.7.0 in
microk8s and openstack-hypervisor plans.

Fixes: LP#2019790