### PR TITLE
Change preseed option return object to Path

### DIFF
--- a/sunbeam/commands/bootstrap.py
+++ b/sunbeam/commands/bootstrap.py
@@ -74,7 +74,12 @@ snap = Snap()
 
 @click.command()
 @click.option("-a", "--accept-defaults", help="Accept all defaults.", is_flag=True)
-@click.option("-p", "--preseed", help="Preseed file.", type=click.Path())
+@click.option(
+    "-p",
+    "--preseed",
+    help="Preseed file.",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+)
 @click.option(
     "--role",
     multiple=True,


### PR DESCRIPTION
Currently preseed option returns a string.
Pass options to click.Path() to return a
Path object.
Check for existance of file if user provides
preseed file.

Fixes: LP#2019874