### PR TITLE
Check name is valid FQDN when adding node

### DIFF
--- a/sunbeam/commands/node.py
+++ b/sunbeam/commands/node.py
@@ -55,6 +55,7 @@ from sunbeam.jobs.checks import (
     JujuSnapCheck,
     LocalShareCheck,
     SshKeysConnectedCheck,
+    VerifyFQDNCheck,
 )
 from sunbeam.jobs.common import (
     ResultType,
@@ -71,15 +72,28 @@ console = Console()
 snap = Snap()
 
 
+def remove_trailing_dot(value: str) -> str:
+    """Remove trailing dot from the value."""
+    return value.rstrip(".")
+
+
 @click.command()
-@click.option("--name", type=str, prompt=True, help="Fully qualified node name")
+@click.option(
+    "--name",
+    type=str,
+    prompt=True,
+    callback=remove_trailing_dot,
+    help="Fully qualified node name",
+)
 def add(name: str) -> None:
     """Generates a token for a new server.
 
     Register new node to the cluster.
     """
-    preflight_checks = [DaemonGroupCheck()]
+    preflight_checks = [DaemonGroupCheck(), VerifyFQDNCheck(name)]
     run_preflight_checks(preflight_checks, console)
+
+    name = remove_trailing_dot(name)
 
     plan1 = [
         ClusterAddNodeStep(name),

--- a/tests/unit/sunbeam/jobs/test_checks.py
+++ b/tests/unit/sunbeam/jobs/test_checks.py
@@ -91,3 +91,61 @@ class TestLocalShareCheck:
         assert result is False
         assert "directory not detected" in check.message
         os.path.exists.assert_called_with(PosixPath("/home/ubuntu/.local/share"))
+
+
+class TestVerifyFQDNCheck:
+    def test_run(self):
+        name = "myhost.mydomain.net"
+        check = checks.VerifyFQDNCheck(name)
+
+        result = check.run()
+
+        assert result is True
+
+    def test_run_hostname_fqdn(self):
+        name = "myhost."
+        check = checks.VerifyFQDNCheck(name)
+
+        result = check.run()
+
+        assert result is True
+
+    def test_run_hostname_pqdn(self):
+        name = "myhost"
+        check = checks.VerifyFQDNCheck(name)
+
+        result = check.run()
+
+        assert result is False
+
+    def test_run_fqdn_invalid_character(self):
+        name = "myhost.mydomain.net!"
+        check = checks.VerifyFQDNCheck(name)
+
+        result = check.run()
+
+        assert result is False
+
+    def test_run_fqdn_starts_with_hyphen(self):
+        name = "-myhost.mydomain.net"
+        check = checks.VerifyFQDNCheck(name)
+
+        result = check.run()
+
+        assert result is False
+
+    def test_run_fqdn_starts_with_dot(self):
+        name = ".myhost.mydomain.net"
+        check = checks.VerifyFQDNCheck(name)
+
+        result = check.run()
+
+        assert result is False
+
+    def test_run_fqdn_too_long(self):
+        name = "myhost.mydomain.net" * 50
+        check = checks.VerifyFQDNCheck(name)
+
+        result = check.run()
+
+        assert result is False


### PR DESCRIPTION
Add node can receive any free form text, but the joining node will use the FQDN. Adding some validation to prevent some mistakes as, short of performing network calls in a well setup environment, we cannot be sure a name is a FQDN.