### PR TITLE
Change configure preseed option return obj to Path

### DIFF
--- a/sunbeam/commands/configure.py
+++ b/sunbeam/commands/configure.py
@@ -582,7 +582,12 @@ class SetLocalHypervisorOptions(BaseStep):
 
 @click.command()
 @click.option("-a", "--accept-defaults", help="Accept all defaults.", is_flag=True)
-@click.option("-p", "--preseed", help="Preseed file.")
+@click.option(
+    "-p",
+    "--preseed",
+    help="Preseed file.",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+)
 @click.option("-o", "--openrc", help="Output file for cloud access details.")
 def configure(
     openrc: str = None, preseed: str = None, accept_defaults: bool = False


### PR DESCRIPTION
Currently preseed option returns a string.
Pass options to click.Path() to return a Path object.
Check for existance of file if user provide preseed file.