### PR TITLE
add node: drop click callback

### DIFF
--- a/sunbeam/commands/node.py
+++ b/sunbeam/commands/node.py
@@ -82,7 +82,6 @@ def remove_trailing_dot(value: str) -> str:
     "--name",
     type=str,
     prompt=True,
-    callback=remove_trailing_dot,
     help="Fully qualified node name",
 )
 def add(name: str) -> None:


### PR DESCRIPTION
The callback signature is not compatible and is used in the actual command function anyway.