### PR TITLE
Fix help for role option

### DIFF
--- a/sunbeam/commands/bootstrap.py
+++ b/sunbeam/commands/bootstrap.py
@@ -88,7 +88,8 @@ snap = Snap()
     type=click.Choice(["control", "compute", "storage"], case_sensitive=False),
     callback=validate_roles,
     help="Specify whether the node will be a control node, a "
-    "compute node or a storage node. Defaults to all the roles.",
+    "compute node or a storage node. Defaults to control and "
+    "compute roles.",
 )
 @click_option_topology
 @click.option(

--- a/sunbeam/commands/node.py
+++ b/sunbeam/commands/node.py
@@ -128,7 +128,8 @@ def add(name: str) -> None:
     type=click.Choice(["control", "compute", "storage"], case_sensitive=False),
     callback=validate_roles,
     help="Specify whether the node will be a control node, a "
-    "compute node or a storage node. Defaults to all the roles.",
+    "compute node or a storage node. Defaults to control and "
+    "compute roles.",
 )
 def join(token: str, role: List[Role]) -> None:
     """Join node to the cluster.


### PR DESCRIPTION
The defaults for role option is control
and compute. The help description for
option role in bootstrap and join command
is changed accordingly.