### PR TITLE
logging: mute juju warning messages

### DIFF
--- a/sunbeam/log.py
+++ b/sunbeam/log.py
@@ -50,8 +50,11 @@ def setup_root_logging():
     # Some logging from the Juju (and dependent) libraries are a bit
     # noisy. Let's reduce the logging output from these dependencies.
     # TODO(wolsen) determine if we need to support a -vvv type option
-    for namespace in ["juju", "websockets", "kubernetes.client"]:
+    for namespace in ["websockets", "kubernetes.client"]:
         logging.getLogger(namespace).setLevel(logging.WARNING)
+    # Mute juju logging to avoid missing facade warning messages
+    for namespace in ["juju"]:
+        logging.getLogger(namespace).setLevel(logging.ERROR)
 
     # If the console is enabled, then enable the RichHandler as it will
     # put the log messages to the line and still honor current console


### PR DESCRIPTION
The juju module generates alot of warning messages about missing facades depending on the version of Juju in use and whether the python-libjuju version matches.

Only display ERROR level messages for the 'juju' module and submodules.