### PR TITLE
demo-setup: rename default image to 'ubuntu'

### DIFF
--- a/cloud/etc/demo-setup/main.tf
+++ b/cloud/etc/demo-setup/main.tf
@@ -43,12 +43,16 @@ resource "openstack_compute_flavor_v2" "m1_large" {
   is_public = true
 }
 
-resource "openstack_images_image_v2" "ubuntu_jammy" {
-  name             = "ubuntu-jammy"
+resource "openstack_images_image_v2" "ubuntu" {
+  name             = "ubuntu"
   image_source_url = "http://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img"
   container_format = "bare"
   disk_format      = "qcow2"
   visibility       = "public"
+  properties {
+    architecture    = "x86_64"
+    hypervisor_type = "qemu"
+  }
 }
 
 # External networking


### PR DESCRIPTION
Rather than having the codename of the image in its name, simply use the name 'ubuntu' for the image uploaded as part of the demo setup.

Add a minimal set of properties to the image.