### PR TITLE
Retrieve dashboard URL

### DIFF
--- a/sunbeam/commands/dashboard_url.py
+++ b/sunbeam/commands/dashboard_url.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2022 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+import click
+from rich.console import Console
+from snaphelpers import Snap
+
+from sunbeam.commands.openstack import OPENSTACK_MODEL
+from sunbeam.jobs import juju
+
+LOG = logging.getLogger(__name__)
+console = Console()
+snap = Snap()
+
+
+@click.command()
+def dashboard_url() -> None:
+    """Retrieve OpenStack Dashboard URL."""
+    data_location = snap.paths.user_data
+    jhelper = juju.JujuHelper(data_location)
+
+    with console.status("Retrieving dashboard URL from Horizon service ... "):
+        # Retrieve config from juju actions
+        model = OPENSTACK_MODEL
+        app = "horizon"
+        action_cmd = "get-dashboard-url"
+        unit = juju.run_sync(jhelper.get_leader_unit(app, model))
+        if not unit:
+            _message = f"Unable to get {app} leader"
+            raise click.ClickException(_message)
+
+        action_result = juju.run_sync(jhelper.run_action(unit, model, action_cmd))
+
+        if action_result.get("return-code", 0) > 1:
+            _message = "Unable to retrieve openrc from Keystone service"
+            raise click.ClickException(_message)
+        else:
+            console.print(action_result.get("url"))

--- a/sunbeam/commands/dashboard_url.py
+++ b/sunbeam/commands/dashboard_url.py
@@ -46,7 +46,7 @@ def dashboard_url() -> None:
         action_result = juju.run_sync(jhelper.run_action(unit, model, action_cmd))
 
         if action_result.get("return-code", 0) > 1:
-            _message = "Unable to retrieve openrc from Keystone service"
+            _message = "Unable to retrieve URL from Horizon service"
             raise click.ClickException(_message)
         else:
             console.print(action_result.get("url"))

--- a/sunbeam/main.py
+++ b/sunbeam/main.py
@@ -26,6 +26,7 @@ from sunbeam.commands import node as node_cmds
 from sunbeam.commands import openrc as openrc_cmds
 from sunbeam.commands import prepare_node as prepare_node_cmds
 from sunbeam.commands import resize as resize_cmds
+from sunbeam.commands import dashboard_url as dasboard_url_cmds
 
 LOG = logging.getLogger()
 
@@ -61,6 +62,7 @@ def main():
     cli.add_command(generate_preseed_cmds.generate_preseed)
     cli.add_command(inspect_cmds.inspect)
     cli.add_command(openrc_cmds.openrc)
+    cli.add_command(dasboard_url_cmds.dashboard_url)
     cluster.add_command(bootstrap_cmds.bootstrap)
     cluster.add_command(node_cmds.add)
     cluster.add_command(node_cmds.join)


### PR DESCRIPTION
Make it easier for the end user to get the URL to the dashboard rather than having to use Juju commands to get this information:

$ sunbeam dashboard-url
http{s}://{ingress-ip}:80/{dashboard-path}

Depends-On: https://review.opendev.org/c/openstack/charm-horizon-k8s/+/883840