### PR TITLE
register: deal with failed auto-login

### DIFF
--- a/sunbeam/commands/juju.py
+++ b/sunbeam/commands/juju.py
@@ -597,7 +597,7 @@ class AddJujuMachineStep(BaseStep, JujuStepHelper):
             child = pexpect.spawn(
                 self._get_juju_binary(),
                 ["add-machine", "-m", CONTROLLER_MODEL, f"ssh:{self.machine_ip}"],
-                PEXPECT_TIMEOUT * 3,  # 3 minutes
+                PEXPECT_TIMEOUT * 5,  # 5 minutes
             )
             with open(log_file, "wb+") as f:
                 # Record the command output, but only the contents streaming from the

--- a/sunbeam/commands/juju.py
+++ b/sunbeam/commands/juju.py
@@ -490,10 +490,16 @@ class RegisterJujuUserStep(BaseStep, JujuStepHelper):
         new_password_re = r"Enter a new password"
         confirm_password_re = r"Confirm password"
         controller_name_re = r"Enter a name for this controller"
+        # NOTE(jamespage)
+        # Sometimes the register command fails to actually log the user in and the
+        # user is prompted to enter the password they literally just set.
+        # https://bugs.launchpad.net/juju/+bug/2020360
+        please_enter_password_re = r"please enter password"
         expect_list = [
             new_password_re,
             confirm_password_re,
             controller_name_re,
+            please_enter_password_re,
             pexpect.EOF,
         ]
 
@@ -522,11 +528,11 @@ class RegisterJujuUserStep(BaseStep, JujuStepHelper):
                         "Juju registraton: expect got regex related to "
                         f"{expect_list[index]}"
                     )
-                    if index == 0 or index == 1:
+                    if index in (0, 1, 3):
                         child.sendline(self.juju_account.password)
                     elif index == 2:
                         child.sendline(self.controller)
-                    elif index == 3:
+                    elif index == 4:
                         result = child.before.decode()
                         if "ERROR" in result:
                             str_index = result.find("ERROR")


### PR DESCRIPTION
Sometime juju fails to login as part of the initial user registration.

Detect the prompt and provide the password just set if this situation is detected.