### PR TITLE
Check release is jammy

### DIFF
--- a/sunbeam/commands/prepare_node.py
+++ b/sunbeam/commands/prepare_node.py
@@ -20,8 +20,13 @@ console = Console()
 
 
 JUJU_CHANNEL = "3.2/beta"
+SUPPORTED_RELEASE = "jammy"
 
 PREPARE_NODE_TEMPLATE = f"""#!/bin/bash
+
+[ $(lsb_release -sc) != '{SUPPORTED_RELEASE}' ] && \
+{{ echo 'ERROR Sunbeam deploy only supported on {SUPPORTED_RELEASE}'; exit 1; }}
+
 # :warning: Node Preparation for OpenStack Sunbeam :warning:
 # All of these commands perform privileged operations
 # please review carefully before execution.


### PR DESCRIPTION
Sunbeam is currently only supported on Jammy. Due to snap confinement the only place the Ubuntu version can be checked is the prepare script so the PR adds a check in there.