### PR TITLE
properties is an object not a block

### DIFF
--- a/cloud/etc/demo-setup/main.tf
+++ b/cloud/etc/demo-setup/main.tf
@@ -49,6 +49,11 @@ resource "openstack_images_image_v2" "ubuntu" {
   container_format = "bare"
   disk_format      = "qcow2"
   visibility       = "public"
+  
+  properties = {
+    architecture    = "x86_64"
+    hypervisor_type = "qemu"
+  }
 }
 
 # External networking


### PR DESCRIPTION
The previous implementation of the properties attribute had a typo.
 It should have been properties = {} instead of just properties {}.

This commit puts the properties back in place but without the typo.