### PR TITLE
Check for passwordless sudo for user

### DIFF
--- a/sunbeam/commands/prepare_node.py
+++ b/sunbeam/commands/prepare_node.py
@@ -32,6 +32,11 @@ PREPARE_NODE_TEMPLATE = f"""#!/bin/bash
 # please review carefully before execution.
 USER=$(whoami)
 
+# Check if user has passwordless sudo permissions
+SUDO_ASKPASS=/bin/false sudo -A whoami &> /dev/null && \
+sudo grep -r $USER /etc/{sudoers,sudoers.d} | grep NOPASSWD:ALL &> /dev/null || \
+{{ echo "ERROR: password-less sudo access to root for user $USER required"; exit 1; }}
+
 # Connect snap to the ssh-keys interface to allow
 # read access to private keys - this supports bootstrap
 # of the Juju controller to the local machine via SSH.


### PR DESCRIPTION
Check if user has passwordless sudo permissions
in prepare_node_script.
Check if user has sudo access using askpass. If it is successful, check for username with NOPASSWD:ALL in sudoers files. If both the checks fails, exit
with an error.