### PR TITLE
Tune exception handling not to show stacktrace in default mode

### DIFF
--- a/sunbeam/main.py
+++ b/sunbeam/main.py
@@ -28,6 +28,7 @@ from sunbeam.commands import node as node_cmds
 from sunbeam.commands import openrc as openrc_cmds
 from sunbeam.commands import prepare_node as prepare_node_cmds
 from sunbeam.commands import resize as resize_cmds
+from sunbeam.utils import CatchGroup
 
 LOG = logging.getLogger()
 
@@ -36,7 +37,7 @@ LOG = logging.getLogger()
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 
 
-@click.group("init", context_settings=CONTEXT_SETTINGS)
+@click.group("init", context_settings=CONTEXT_SETTINGS, cls=CatchGroup)
 @click.option("--quiet", "-q", default=False, is_flag=True)
 @click.option("--verbose", "-v", default=False, is_flag=True)
 @click.pass_context
@@ -49,7 +50,7 @@ def cli(ctx, quiet, verbose):
     """
 
 
-@click.group("cluster", context_settings=CONTEXT_SETTINGS)
+@click.group("cluster", context_settings=CONTEXT_SETTINGS, cls=CatchGroup)
 @click.pass_context
 def cluster(ctx):
     """Manage the Sunbeam Cluster"""

--- a/sunbeam/utils.py
+++ b/sunbeam/utils.py
@@ -16,8 +16,10 @@
 import glob
 import logging
 import socket
+import sys
 from pathlib import Path
 
+import click
 import netifaces
 import pwgen
 from pyroute2 import IPDB, NDB
@@ -118,3 +120,15 @@ def get_free_nic() -> str:
 def generate_password() -> str:
     """Generate a password."""
     return pwgen.pwgen(12)
+
+
+class CatchGroup(click.Group):
+    """Catch exceptions and print them to stderr."""
+
+    def __call__(self, *args, **kwargs):
+        try:
+            return self.main(*args, **kwargs)
+        except Exception as e:
+            LOG.debug(e, exc_info=True)
+            LOG.error("Error: %s", e)
+            sys.exit(1)


### PR DESCRIPTION
Add a global exception catcher to click groups to control error output. In default configuration, no stacktrace should be show to the user.
Adding the parameter `-v`/`--verbose` will print the stacktrace.



Default behavior:
```bash
ubuntu@bm0:~$ openstack.sunbeam dashboard-url
Error: ConfigItem not found
ubuntu@bm0:~$ echo $?
1
```

Debug behavior:
```
ubuntu@bm0:~$ openstack.sunbeam -v dashboard-url
[09:01:02] DEBUG    Using selector: EpollSelector                                                                                                                                                                                  selector_events.py:54
           DEBUG    /var/snap/openstack/common/state/control.socket                                                                                                                                                                       service.py:109
           DEBUG    [get] http+unix://%2Fvar%2Fsnap%2Fopenstack%2Fcommon%2Fstate%2Fcontrol.socket/1.0/config/JujuController, args={'allow_redirects': True}                                                                               service.py:118
           DEBUG    http://localhost:None "GET /1.0/config/JujuController HTTP/1.1" 404 125                                                                                                                                        connectionpool.py:456
           DEBUG    Response(<Response [404]>) = {"type":"error","status":"","status_code":0,"operation":"","error_code":404,"error":"ConfigItem not found","metadata":null}                                                              service.py:120
                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                        
           DEBUG    ConfigItem not found                                                                                                                                                                                                    utils.py:132
                    Traceback (most recent call last):                                                                                                                                                                                                  
                      File "/snap/openstack/x4/lib/python3.10/site-packages/sunbeam/clusterd/service.py", line 125, in _request                                                                                                                         
                        response.raise_for_status()                                                                                                                                                                                                     
                      File "/snap/openstack/x4/lib/python3.10/site-packages/requests/models.py", line 1021, in raise_for_status                                                                                                                         
                        raise HTTPError(http_error_msg, response=self)                                                                                                                                                                                  
                    requests.exceptions.HTTPError: 404 Client Error: Not Found for url: http+unix://%2Fvar%2Fsnap%2Fopenstack%2Fcommon%2Fstate%2Fcontrol.socket/1.0/config/JujuController                                                               
                                                                                                                                                                                                                                                        
                    During handling of the above exception, another exception occurred:                                                                                                                                                                 
                                                                                                                                                                                                                                                        
                    Traceback (most recent call last):                                                                                                                                                                                                  
                      File "/snap/openstack/x4/lib/python3.10/site-packages/sunbeam/utils.py", line 130, in __call__                                                                                                                                    
                        return self.main(*args, **kwargs)                                                                                                                                                                                               
                      File "/snap/openstack/x4/lib/python3.10/site-packages/click/core.py", line 1055, in main                                                                                                                                          
                        rv = self.invoke(ctx)                                                                                                                                                                                                           
                      File "/snap/openstack/x4/lib/python3.10/site-packages/click/core.py", line 1657, in invoke                                                                                                                                        
                        return _process_result(sub_ctx.command.invoke(sub_ctx))                                                                                                                                                                         
                      File "/snap/openstack/x4/lib/python3.10/site-packages/click/core.py", line 1404, in invoke                                                                                                                                        
                        return ctx.invoke(self.callback, **ctx.params)                                                                                                                                                                                  
                      File "/snap/openstack/x4/lib/python3.10/site-packages/click/core.py", line 760, in invoke                                                                                                                                         
                        return __callback(*args, **kwargs)                                                                                                                                                                                              
                      File "/snap/openstack/x4/lib/python3.10/site-packages/sunbeam/commands/dashboard_url.py", line 41, in dashboard_url                                                                                                               
                        unit = juju.run_sync(jhelper.get_leader_unit(app, model))                                                                                                                                                                       
                      File "/snap/openstack/x4/lib/python3.10/site-packages/sunbeam/jobs/juju.py", line 56, in run_sync                                                                                                                                 
                        result = asyncio.get_event_loop().run_until_complete(coro)                                                                                                                                                                      
                      File "/usr/lib/python3.10/asyncio/base_events.py", line 646, in run_until_complete                                                                                                                                                
                        return future.result()                                                                                                                                                                                                          
                      File "/snap/openstack/x4/lib/python3.10/site-packages/sunbeam/jobs/juju.py", line 176, in wrapper                                                                                                                                 
                        juju_controller = JujuController.load(client)                                                                                                                                                                                   
                      File "/snap/openstack/x4/lib/python3.10/site-packages/sunbeam/jobs/juju.py", line 162, in load                                                                                                                                    
                        controller = client.cluster.get_config(JUJU_CONTROLLER_KEY)                                                                                                                                                                     
                      File "/snap/openstack/x4/lib/python3.10/site-packages/sunbeam/clusterd/cluster.py", line 159, in get_config                                                                                                                       
                        return self._get(f"/1.0/config/{key}").get("metadata")                                                                                                                                                                          
                      File "/snap/openstack/x4/lib/python3.10/site-packages/sunbeam/clusterd/service.py", line 175, in _get                                                                                                                             
                        return self._request("get", path, **kwargs)                                                                                                                                                                                     
                      File "/snap/openstack/x4/lib/python3.10/site-packages/sunbeam/clusterd/service.py", line 168, in _request                                                                                                                         
                        raise ConfigItemNotFoundException("ConfigItem not found")                                                                                                                                                                       
                    sunbeam.clusterd.service.ConfigItemNotFoundException: ConfigItem not found                                                                                                                                                          
           ERROR    Error: ConfigItem not found
ubuntu@bm0:~$ echo $?
1
```


This catcher does not alter the behavior of `ClickException` errors.

For example, when a Check fails, the result is still:
```
ubuntu@bm0:~$ sudo snap disconnect openstack:ssh-keys
ubuntu@bm0:~$ openstack.sunbeam cluster bootstrap
Error: ssh-keys interface not detected
Please connect ssh-keys interface by running:

    sudo snap connect openstack:ssh-keys
```




