### PR TITLE
Fix test hypervisor mocking

### DIFF
--- a/tests/unit/sunbeam/commands/test_hypervisor.py
+++ b/tests/unit/sunbeam/commands/test_hypervisor.py
@@ -40,7 +40,7 @@ def mock_run_sync(mocker):
     def run_sync(coro):
         return loop.run_until_complete(coro)
 
-    mocker.patch("sunbeam.commands.openstack.run_sync", run_sync)
+    mocker.patch("sunbeam.commands.hypervisor.run_sync", run_sync)
     yield
     loop.close()
 


### PR DESCRIPTION
Hypervisor tests mocked the wrongs function, resulting in a lot of warnings (no errors).