### PR TITLE
Add --client option to juju add-cloud

### DIFF
--- a/sunbeam/commands/juju.py
+++ b/sunbeam/commands/juju.py
@@ -158,6 +158,7 @@ class JujuStepHelper:
                 cloud_name,
                 "--file",
                 temp.name,
+                "--client",
             ]
             LOG.debug(f'Running command {" ".join(cmd)}')
             process = subprocess.run(cmd, capture_output=True, text=True, check=True)


### PR DESCRIPTION
Juju in general asks the user during add-cloud
operation whether to apply at client or controller or both. By the add-cloud execution time, controller does not exist yet and so add --client option to
inform juju to add cloud at client level.
This will also avoid juju asking queries that requires human intervention.