### PR TITLE
console output: avoid wrapping output

### DIFF
--- a/sunbeam-python/sunbeam/commands/node.py
+++ b/sunbeam-python/sunbeam/commands/node.py
@@ -125,7 +125,7 @@ def add(name: str, format: str) -> None:
     def _print_output(token):
         """Helper for printing formatted output."""
         if format == FORMAT_DEFAULT:
-            console.print(f"Token for the Node {name}: {token}")
+            console.print(f"Token for the Node {name}: {token}", soft_wrap=True)
         elif format == FORMAT_YAML:
             click.echo(yaml.dump({"token": token}))
         elif format == FORMAT_VALUE:

--- a/sunbeam-python/sunbeam/commands/prepare_node.py
+++ b/sunbeam-python/sunbeam/commands/prepare_node.py
@@ -64,4 +64,4 @@ mkdir -p $HOME/.local/share
 @click.command()
 def prepare_node_script() -> None:
     """Generate script to prepare a node for Sunbeam use."""
-    console.print(PREPARE_NODE_TEMPLATE)
+    console.print(PREPARE_NODE_TEMPLATE, soft_wrap=True)


### PR DESCRIPTION
Use the soft_wrap flag when printing output via the Rich console; this avoids wrapping and truncation when used in scripting and in reduced width terminals.

Impacts on the prepare-node-script and when printing tokens in the default format output for 'cluster add' commands.