### PR TITLE
Fix prepare-node-script

### DIFF
--- a/sunbeam-python/sunbeam/commands/prepare_node.py
+++ b/sunbeam-python/sunbeam/commands/prepare_node.py
@@ -33,8 +33,8 @@ PREPARE_NODE_TEMPLATE = f"""#!/bin/bash
 USER=$(whoami)
 
 # Check if user has passwordless sudo permissions
-SUDO_ASKPASS=/bin/false sudo -A whoami &> /dev/null && \
-sudo grep -r $USER /etc/{{sudoers,sudoers.d}} | grep NOPASSWD:ALL &> /dev/null || \
+SUDO_ASKPASS=/bin/false sudo -A whoami &> /dev/null &&
+sudo grep -r $USER /etc/{{sudoers,sudoers.d}} | grep NOPASSWD:ALL &> /dev/null ||
 {{ echo "ERROR: password-less sudo access to root for user $USER required"; exit 1; }}
 
 # Connect snap to the ssh-keys interface to allow


### PR DESCRIPTION
passwordless sudo snippet in prepare-node-script
does not work when executed via remote ssh, the
reason being the script gets trimmed and multi line strings are broken.
Fix the snippet by removing backlashes.

Fixes: LP#2020786