### PR TITLE
Juju 3.2/stable has been released. Use as default.

### DIFF
--- a/sunbeam-python/sunbeam/commands/prepare_node.py
+++ b/sunbeam-python/sunbeam/commands/prepare_node.py
@@ -19,7 +19,7 @@ from rich.console import Console
 console = Console()
 
 
-JUJU_CHANNEL = "3.2/beta"
+JUJU_CHANNEL = "3.2/stable"
 SUPPORTED_RELEASE = "jammy"
 
 PREPARE_NODE_TEMPLATE = f"""#!/bin/bash


### PR DESCRIPTION
sunbeam-python/requirements.txt will be updated when a 3.2 is released for pylibjuju