### PR TITLE
Implement debug option for clusterd

### DIFF
--- a/snap-wrappers/commands/clusterd.start
+++ b/snap-wrappers/commands/clusterd.start
@@ -1,15 +1,10 @@
 #!/bin/sh
 export DQLITE_SOCKET="@snap.${SNAP_INSTANCE_NAME}.dqlite"
 export SOCKET_GROUP="$(snapctl get 'daemon.group')"
-export LOG=""
+export DEBUG=""
 
-if [ "$(snapctl get daemon.verbose)" != "false" ]; then
-  export LOG="--verbose"
-fi
-
-# debug as priority over verbose, setting it last
 if [ "$(snapctl get daemon.debug)" != "false" ]; then
-  export LOG="--debug"
+  export DEBUG="--debug"
 fi
 
-exec sunbeamd --state-dir "${SNAP_COMMON}/state" --socket-group "${SOCKET_GROUP}" $LOG
+exec sunbeamd --state-dir "${SNAP_COMMON}/state" --socket-group "${SOCKET_GROUP}" --verbose $DEBUG

--- a/snap-wrappers/commands/clusterd.start
+++ b/snap-wrappers/commands/clusterd.start
@@ -1,5 +1,15 @@
 #!/bin/sh
 export DQLITE_SOCKET="@snap.${SNAP_INSTANCE_NAME}.dqlite"
 export SOCKET_GROUP="$(snapctl get 'daemon.group')"
+export LOG=""
 
-exec sunbeamd --state-dir "${SNAP_COMMON}/state" --socket-group "${SOCKET_GROUP}"
+if [ "$(snapctl get daemon.verbose)" != "false" ]; then
+  export LOG="--verbose"
+fi
+
+# debug as priority over verbose, setting it last
+if [ "$(snapctl get daemon.debug)" != "false" ]; then
+  export LOG="--debug"
+fi
+
+exec sunbeamd --state-dir "${SNAP_COMMON}/state" --socket-group "${SOCKET_GROUP}" $LOG

--- a/sunbeam-python/sunbeam/hooks.py
+++ b/sunbeam-python/sunbeam/hooks.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 import logging
+import json
+from pathlib import Path
 
 from snaphelpers import Snap
 
@@ -23,21 +25,44 @@ DEFAULT_CONFIG = {
     "juju.cloud.type": "manual",
     "juju.cloud.name": "sunbeam",
     "daemon.group": "snap_daemon",
+    "daemon.debug": False,
+    "daemon.verbose": False,
 }
+
+OPTION_KEYS = set(k.split(".")[0] for k in DEFAULT_CONFIG.keys())
 
 
 def _update_default_config(snap: Snap) -> None:
     """Add any missing default configuration keys.
 
     :param snap: the snap reference
-    :type snap: Snap
-    :return: None
     """
-    option_keys = set([k.split(".")[0] for k in DEFAULT_CONFIG.keys()])
-    current_options = snap.config.get_options(*option_keys)
+    current_options = snap.config.get_options(*OPTION_KEYS)
     for option, default in DEFAULT_CONFIG.items():
         if option not in current_options:
             snap.config.set({option: default})
+
+
+def _write_config(path: Path, config: dict) -> None:
+    """Write the configuration to the specified path.
+
+    :param path: the path to write the configuration to
+    :param config: the configuration to write
+    """
+    with path.open("w") as fp:
+        json.dump(config, fp)
+
+
+def _read_config(path: Path) -> dict:
+    """Read the configuration from the specified path.
+
+    :param path: the path to read the configuration from
+    :return: the configuration
+    """
+    if not path.exists():
+        return {}
+    with path.open("r") as fp:
+        return json.load(fp) or {}
 
 
 def install(snap: Snap) -> None:
@@ -63,8 +88,7 @@ def upgrade(snap: Snap) -> None:
     The 'upgrade' hook will upgrade the various bundle information, etc. This
     is
 
-    :param snap:
-    :return:
+    :param snap: the snap reference
     """
     setup_logging(snap.paths.common / "hooks.log")
     LOG.debug("Running the upgrade hook...")
@@ -78,10 +102,15 @@ def configure(snap: Snap) -> None:
     set openstack.<foo> setting.
 
     :param snap: the snap reference
-    :type snap: Snap
-    :return: None
     """
     setup_logging(snap.paths.common / "hooks.log")
     logging.info("Running configure hook")
 
     _update_default_config(snap)
+
+    config_path = snap.paths.data / "config.yaml"
+    old_config = _read_config(config_path)
+    new_config = snap.config.get_options(*OPTION_KEYS).as_dict()
+    _write_config(config_path, new_config)
+    if old_config.get("daemon") != new_config.get("daemon"):
+        snap.services.list()["clusterd"].restart()

--- a/sunbeam-python/sunbeam/hooks.py
+++ b/sunbeam-python/sunbeam/hooks.py
@@ -26,7 +26,6 @@ DEFAULT_CONFIG = {
     "juju.cloud.name": "sunbeam",
     "daemon.group": "snap_daemon",
     "daemon.debug": False,
-    "daemon.verbose": False,
 }
 
 OPTION_KEYS = set(k.split(".")[0] for k in DEFAULT_CONFIG.keys())


### PR DESCRIPTION
This change allows for enabling through `snap set...` the two level of logging available with microcluster.

Enabling levels:
  - ~`snap set openstack daemon.verbose=true` enables verbose logging~
  - `snap set openstack daemon.debug=true` enables debug logging

Debug logging always takes precedence over verbose logging