### PR TITLE
cinder-ceph exclusion in wait operation

### DIFF
--- a/sunbeam-python/sunbeam/commands/openstack.py
+++ b/sunbeam-python/sunbeam/commands/openstack.py
@@ -315,9 +315,15 @@ class ResizeControlPlaneStep(BaseStep, JujuStepHelper):
             return Result(ResultType.FAILED, str(e))
 
         try:
+            # Remove cinder-ceph from apps to wait on if ceph is not enabled
+            apps = run_sync(self.jhelper.get_application_names(self.model))
+            if not storage_nodes and "cinder-ceph" in apps:
+                apps.remove("cinder-ceph")
+
             run_sync(
                 self.jhelper.wait_until_active(
                     self.model,
+                    apps,
                     timeout=OPENSTACK_DEPLOY_TIMEOUT,
                 )
             )

--- a/sunbeam-python/sunbeam/utils.py
+++ b/sunbeam-python/sunbeam/utils.py
@@ -18,7 +18,7 @@ import logging
 import socket
 import sys
 from pathlib import Path
-from typing import List, Dict
+from typing import Dict, List
 
 import click
 import netifaces


### PR DESCRIPTION
Exclude cinder-ceph from the app list to wait
for during resize operation.
tox -e fmt formatting changes.