### PR TITLE
Refactor role structure

### DIFF
--- a/sunbeam-microcluster/api/nodes.go
+++ b/sunbeam-microcluster/api/nodes.go
@@ -33,15 +33,9 @@ var nodeCmd = rest.Endpoint{
 }
 
 func cmdNodesGetAll(s *state.State, r *http.Request) response.Response {
-	var role *string
+	roles := r.URL.Query()["role"]
 
-	roleParam := r.URL.Query().Get("role")
-
-	if roleParam != "" {
-		role = &roleParam
-	}
-
-	nodes, err := sunbeam.ListNodes(s, role)
+	nodes, err := sunbeam.ListNodes(s, roles)
 	if err != nil {
 		return response.InternalError(err)
 	}

--- a/sunbeam-microcluster/api/types/nodes.go
+++ b/sunbeam-microcluster/api/types/nodes.go
@@ -6,7 +6,7 @@ type Nodes []Node
 
 // Node structure to hold node details like role and machine id
 type Node struct {
-	Name      string `json:"name" yaml:"name"`
-	Role      string `json:"role" yaml:"role"`
-	MachineID int    `json:"machineid" yaml:"machineid"`
+	Name      string   `json:"name" yaml:"name"`
+	Role      []string `json:"role" yaml:"role"`
+	MachineID int      `json:"machineid" yaml:"machineid"`
 }

--- a/sunbeam-microcluster/sunbeam/nodes.go
+++ b/sunbeam-microcluster/sunbeam/nodes.go
@@ -3,7 +3,9 @@ package sunbeam
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"fmt"
+	"sort"
 
 	"github.com/canonical/microcluster/state"
 
@@ -12,26 +14,24 @@ import (
 )
 
 // ListNodes return all the nodes, filterable by role (Optional)
-func ListNodes(s *state.State, role *string) (types.Nodes, error) {
+func ListNodes(s *state.State, roles []string) (types.Nodes, error) {
 	nodes := types.Nodes{}
-
-	filters := make([]database.NodeFilter, 0)
-
-	if role != nil {
-		filters = append(filters, database.NodeFilter{Role: role})
-	}
 
 	// Get the nodes from the database.
 	err := s.Database.Transaction(s.Context, func(ctx context.Context, tx *sql.Tx) error {
-		records, err := database.GetNodes(ctx, tx, filters...)
+		records, err := database.GetNodesFromRoles(ctx, tx, roles)
 		if err != nil {
 			return fmt.Errorf("Failed to fetch nodes: %w", err)
 		}
 
 		for _, node := range records {
+			nodeRole, err := roleFromStr(node.Role)
+			if err != nil {
+				return err
+			}
 			nodes = append(nodes, types.Node{
 				Name:      node.Name,
-				Role:      node.Role,
+				Role:      nodeRole,
 				MachineID: node.MachineID,
 			})
 		}
@@ -54,8 +54,12 @@ func GetNode(s *state.State, name string) (types.Node, error) {
 			return err
 		}
 
+		nodeRole, err := roleFromStr(record.Role)
+		if err != nil {
+			return err
+		}
 		node.Name = record.Name
-		node.Role = record.Role
+		node.Role = nodeRole
 		node.MachineID = record.MachineID
 
 		return nil
@@ -65,10 +69,14 @@ func GetNode(s *state.State, name string) (types.Node, error) {
 }
 
 // AddNode adds a node to the database
-func AddNode(s *state.State, name string, role string, machineid int) error {
+func AddNode(s *state.State, name string, role []string, machineid int) error {
+	nodeRole, err := roleToStr(role)
+	if err != nil {
+		return err
+	}
 	// Add node to the database.
-	err := s.Database.Transaction(s.Context, func(ctx context.Context, tx *sql.Tx) error {
-		_, err := database.CreateNode(ctx, tx, database.Node{Member: s.Name(), Name: name, Role: role, MachineID: machineid})
+	err = s.Database.Transaction(s.Context, func(ctx context.Context, tx *sql.Tx) error {
+		_, err := database.CreateNode(ctx, tx, database.Node{Member: s.Name(), Name: name, Role: nodeRole, MachineID: machineid})
 		if err != nil {
 			return fmt.Errorf("Failed to record node: %w", err)
 		}
@@ -83,22 +91,26 @@ func AddNode(s *state.State, name string, role string, machineid int) error {
 }
 
 // UpdateNode updates a node record in the database
-func UpdateNode(s *state.State, name string, role string, machineid int) error {
+func UpdateNode(s *state.State, name string, role []string, machineid int) error {
+	nodeRole, err := roleToStr(role)
+	if err != nil {
+		return err
+	}
 	// Update node to the database.
-	err := s.Database.Transaction(s.Context, func(ctx context.Context, tx *sql.Tx) error {
+	err = s.Database.Transaction(s.Context, func(ctx context.Context, tx *sql.Tx) error {
 		node, err := database.GetNode(ctx, tx, name)
 		if err != nil {
 			return fmt.Errorf("Failed to retrieve node details: %w", err)
 		}
 
-		if role == "" {
-			role = node.Role
+		if role == nil {
+			nodeRole = node.Role
 		}
 		if machineid == 0 {
 			machineid = node.MachineID
 		}
 
-		err = database.UpdateNode(ctx, tx, name, database.Node{Member: s.Name(), Name: name, Role: role, MachineID: machineid})
+		err = database.UpdateNode(ctx, tx, name, database.Node{Member: s.Name(), Name: name, Role: nodeRole, MachineID: machineid})
 		if err != nil {
 			return fmt.Errorf("Failed to update record node: %w", err)
 		}
@@ -128,4 +140,25 @@ func DeleteNode(s *state.State, name string) error {
 	}
 
 	return nil
+}
+
+// roleToStr converts a role slice to a string sorted
+func roleToStr(role []string) (string, error) {
+	sort.Strings(role)
+	roleJSON, err := json.Marshal(role)
+	if err != nil {
+		return "", fmt.Errorf("Failed to marshal role: %w", err)
+	}
+	return string(roleJSON), nil
+}
+
+// roleFromStr converts a role string to a slice sorted
+func roleFromStr(roleStr string) ([]string, error) {
+	var role []string
+	err := json.Unmarshal([]byte(roleStr), &role)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to unmarshal role: %w", err)
+	}
+	sort.Strings(role)
+	return role, nil
 }

--- a/sunbeam-python/sunbeam/commands/clusterd.py
+++ b/sunbeam-python/sunbeam/commands/clusterd.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 import logging
-from typing import Optional
+from typing import List, Optional
 
 from sunbeam import utils
 from sunbeam.clusterd.client import Client as clusterClient
@@ -41,7 +41,7 @@ LOG = logging.getLogger(__name__)
 class ClusterInitStep(BaseStep):
     """Bootstrap clustering on sunbeam clusterd."""
 
-    def __init__(self, role: str):
+    def __init__(self, role: List[str]):
         super().__init__("Bootstrap Cluster", "Bootstrapping Sunbeam cluster")
 
         self.port = CLUSTERD_PORT
@@ -133,7 +133,7 @@ class ClusterAddNodeStep(BaseStep):
 class ClusterJoinNodeStep(BaseStep):
     """Join node to the sunbeam cluster."""
 
-    def __init__(self, token, role):
+    def __init__(self, token: str, role: List[str]):
         super().__init__("Join node to Cluster", "Adding node to Sunbeam cluster")
 
         self.port = CLUSTERD_PORT
@@ -197,7 +197,7 @@ class ClusterListNodeStep(BaseStep):
                 for member in members
             }
             for node in nodes:
-                nodes_dict[node.get("name")].update({"role": node.get("role")})
+                nodes_dict[node.get("name")].update({"roles": node.get("role", [])})
 
             return Result(result_type=ResultType.COMPLETED, message=nodes_dict)
         except ClusterServiceUnavailableException as e:
@@ -208,7 +208,9 @@ class ClusterListNodeStep(BaseStep):
 class ClusterUpdateNodeStep(BaseStep):
     """Update node info in the cluster database."""
 
-    def __init__(self, name: str, role: str = "", machine_id: int = -1):
+    def __init__(
+        self, name: str, role: Optional[List[str]] = None, machine_id: int = -1
+    ):
         super().__init__("Update node info", "Updating node info in cluster database")
         self.client = clusterClient()
         self.name = name

--- a/sunbeam-python/sunbeam/commands/openstack.py
+++ b/sunbeam-python/sunbeam/commands/openstack.py
@@ -78,10 +78,7 @@ def determine_target_topology(client: Client) -> str:
     """
     control_nodes = client.cluster.list_nodes_by_role("control")
     compute_nodes = client.cluster.list_nodes_by_role("compute")
-    combined = [
-        dict(node)
-        for node in set(tuple(item.items()) for item in control_nodes + compute_nodes)
-    ]
+    combined = set(node["name"] for node in control_nodes + compute_nodes)
     host_total_ram = get_host_total_ram()
     if len(combined) == 1 and host_total_ram < RAM_32_GB_IN_KB:
         topology = "single"

--- a/sunbeam-python/sunbeam/jobs/common.py
+++ b/sunbeam-python/sunbeam/jobs/common.py
@@ -74,6 +74,10 @@ class Role(enum.Enum):
         return self == Role.STORAGE
 
 
+def roles_to_str_list(roles: List[Role]) -> List[str]:
+    return [role.name.lower() for role in roles]
+
+
 class ResultType(enum.Enum):
     COMPLETED = 0
     FAILED = 1


### PR DESCRIPTION
Refactor sunbeam-microcluster api to manage roles as a string list.

Internally stored as a string since microcluster orm does not support slices