### PR TITLE
microk8s: Switch to legacy/stable channel

### DIFF
--- a/cloud/etc/deploy-microk8s/variables.tf
+++ b/cloud/etc/deploy-microk8s/variables.tf
@@ -15,7 +15,7 @@
 
 variable "charm_microk8s_channel" {
   description = "Operator channel for microk8s deployment"
-  default     = "latest/edge"
+  default     = "legacy/stable"
 }
 
 variable "microk8s_channel" {


### PR DESCRIPTION
Switch to using the legacy/stable channel for microk8s; we'll need to switch to the new version of the charm at some point in time but for now this track will keep us stable.