### PR TITLE
prepare-node: ensure openssh-server is installed

### DIFF
--- a/sunbeam-python/sunbeam/commands/prepare_node.py
+++ b/sunbeam-python/sunbeam/commands/prepare_node.py
@@ -37,6 +37,11 @@ SUDO_ASKPASS=/bin/false sudo -A whoami &> /dev/null &&
 sudo grep -r $USER /etc/{{sudoers,sudoers.d}} | grep NOPASSWD:ALL &> /dev/null ||
 {{ echo "ERROR: password-less sudo access to root for user $USER required"; exit 1; }}
 
+# Ensure OpenSSH server is installed
+dpkg -s openssh-server &> /dev/null || {{
+    sudo apt install -y openssh-server
+}}
+
 # Connect snap to the ssh-keys interface to allow
 # read access to private keys - this supports bootstrap
 # of the Juju controller to the local machine via SSH.


### PR DESCRIPTION
Juju requires that the machines being added to the model be accessible over SSH; ensure that OpenSSH server is installed on the current machine or the process of adding the machine to the cloud will fail.