### PR TITLE
Pin version of openstacksdk

### DIFF
--- a/sunbeam-python/upper-constraints.txt
+++ b/sunbeam-python/upper-constraints.txt
@@ -452,7 +452,7 @@ cotyledon===1.7.3
 xattr===0.9.9
 systemd-python===234
 python-memcached===1.59
-openstacksdk===1.0.1
+openstacksdk===0.103.0
 six===1.16.0
 dulwich===0.20.46
 dfs-sdk===1.2.27


### PR DESCRIPTION
This is a temporary workaround to prevent microversions being passed to the Compute API; in later SDK versions this causes resource not found errors to be returned.

The base 2.1 API version works so lets use that for the moment.