### PR TITLE
Support for proxy

### DIFF
--- a/cloud/etc/deploy-microk8s/main.tf
+++ b/cloud/etc/deploy-microk8s/main.tf
@@ -46,5 +46,6 @@ resource "juju_application" "microk8s" {
     channel              = var.microk8s_channel
     addons               = join(" ", [for key, value in var.addons : "${key}:${value}"])
     disable_cert_reissue = true
+    containerd_env       = var.containerd_env
   }
 }

--- a/cloud/etc/deploy-microk8s/variables.tf
+++ b/cloud/etc/deploy-microk8s/variables.tf
@@ -39,3 +39,19 @@ variable "addons" {
   }
 }
 
+variable "containerd_env" {
+  description = "Containerd env file content"
+  type        = string
+  default     = <<EOT
+# This file is managed by Juju. Manual changes may be lost at any time.
+
+# Configure limits for locked memory and maximum number of open files
+ulimit -n 65536 || true
+ulimit -l 16384 || true
+
+# Uncomment to configure a proxy for containerd
+# HTTP_PROXY=http://squid.internal:3128
+# HTTPS_PROXY=http://squid.internal:3128
+# NO_PROXY=10.0.0.0/8,127.0.0.0/16,192.168.0.0/16
+EOT
+}

--- a/sunbeam-python/sunbeam/commands/rocks.py
+++ b/sunbeam-python/sunbeam/commands/rocks.py
@@ -23,7 +23,6 @@ from sunbeam.clusterd.service import NodeNotExistInClusterException
 from sunbeam.jobs.common import BaseStep, Result, ResultType
 from sunbeam.jobs.juju import CONTROLLER_MODEL
 
-
 LOG = logging.getLogger(__name__)
 
 GHCR = "ghcr.io/openstack-snaps/{name}:{tag}"

--- a/sunbeam-python/sunbeam/commands/terraform.py
+++ b/sunbeam-python/sunbeam/commands/terraform.py
@@ -124,12 +124,21 @@ class TerraformHelper:
         timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
         tf_log = str(self.path / f"terraform-init-{timestamp}.log")
         os_env.update({"TF_LOG": "INFO", "TF_LOG_PATH": tf_log})
+        http_proxy = self.snap.config.get("proxy.http_proxy")
+        https_proxy = self.snap.config.get("proxy.https_proxy")
+        no_proxy = self.snap.config.get("proxy.no_proxy")
         if self.env:
             os_env.update(self.env)
         if self.backend:
             self.write_backend_tf()
         if self.data_location:
             os_env.update(self.update_juju_provider_credentials())
+        if http_proxy or https_proxy:
+            os_env.update(
+                HTTP_PROXY=http_proxy,
+                HTTPS_PROXY=https_proxy,
+                NO_PROXY=no_proxy,
+            )
 
         try:
             cmd = [self.terraform, "init", "-upgrade", "-no-color"]

--- a/sunbeam-python/sunbeam/hooks.py
+++ b/sunbeam-python/sunbeam/hooks.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
 import json
+import logging
 from pathlib import Path
 
 from snaphelpers import Snap
@@ -26,6 +26,9 @@ DEFAULT_CONFIG = {
     "juju.cloud.name": "sunbeam",
     "daemon.group": "snap_daemon",
     "daemon.debug": False,
+    "proxy.http_proxy": "",
+    "proxy.https_proxy": "",
+    "proxy.no_proxy": "",
 }
 
 OPTION_KEYS = set(k.split(".")[0] for k in DEFAULT_CONFIG.keys())

--- a/sunbeam-python/tests/unit/sunbeam/commands/test_microk8s.py
+++ b/sunbeam-python/tests/unit/sunbeam/commands/test_microk8s.py
@@ -58,14 +58,17 @@ class TestDeployMicrok8sApplicationStep(unittest.TestCase):
     def __init__(self, methodName: str = "runTest") -> None:
         super().__init__(methodName)
         self.client = patch("sunbeam.commands.microk8s.Client")
+        self.snap = patch("sunbeam.commands.microk8s.Snap")
 
     def setUp(self):
         self.client.start()
+        self.snap.start()
         self.jhelper = AsyncMock()
         self.tfhelper = Mock(path=Path())
 
     def tearDown(self):
         self.client.stop()
+        self.snap.stop()
 
     def test_is_skip(self):
         step = DeployMicrok8sApplicationStep(self.tfhelper, self.jhelper)


### PR DESCRIPTION
In case proxy settings are needed, they need to
be applied for
1. Terraform init to download juju/openstack plugins
2. Containerd service to download container images.

The proxy settings can be queried to user but this has to be done at TerraformInit step. However the
TerraformInit step is called multiple times for each plan. To avoid asking same questions to user multiple times, the proxy settings are made as snap configs.

Introduced new snap configs proxy.http_proxy,
proxy.https_proxy, proxy.no_proxy.
Pass them as env during terraform init.
Update microk8s configuration parameter
containerd_env with proxy settings.

The settings have to be done on every node that runs terraform plan. However in case of containerd, it is only required in bootstrap node as the settings are applied at charm config level.

Ran tox -e fmt for better formatting.