### PR TITLE
Pass https proxy to preseed rocks image pull

### DIFF
--- a/sunbeam-python/sunbeam/commands/microk8s.py
+++ b/sunbeam-python/sunbeam/commands/microk8s.py
@@ -119,9 +119,9 @@ class DeployMicrok8sApplicationStep(BaseStep, JujuStepHelper):
         questions.write_answers(self.client, self._CONFIG, self.variables)
 
         # Check if there are any proxies set and add containerd_env to the variables
-        http_proxy = self.snap.config.get("proxy.http_proxy")
-        https_proxy = self.snap.config.get("proxy.https_proxy")
-        no_proxy = self.snap.config.get("proxy.no_proxy")
+        http_proxy = self.snap.config.get("proxy.http")
+        https_proxy = self.snap.config.get("proxy.https")
+        no_proxy = self.snap.config.get("proxy.no")
         if http_proxy or https_proxy:
             self.variables["containerd_env"] = CONTAINERD_ENV_TEMPLATE.format(
                 http_proxy=http_proxy, https_proxy=https_proxy, no_proxy=no_proxy

--- a/sunbeam-python/sunbeam/commands/rocks.py
+++ b/sunbeam-python/sunbeam/commands/rocks.py
@@ -89,7 +89,7 @@ def run_shell(cmd, check=True):
 def pull_image(machine_id, name, tag):
     image = GHCR.format(name=name, tag=tag)
 
-    https_proxy = snap.config.get("proxy.https_proxy")
+    https_proxy = snap.config.get("proxy.https")
     cmd = SSH + [machine_id]
     if https_proxy:
         cmd.extend([f"https_proxy={https_proxy}"])

--- a/sunbeam-python/sunbeam/commands/rocks.py
+++ b/sunbeam-python/sunbeam/commands/rocks.py
@@ -17,6 +17,7 @@ import subprocess
 from typing import Optional
 
 from rich.status import Status
+from snaphelpers import Snap
 
 from sunbeam.clusterd.client import Client
 from sunbeam.clusterd.service import NodeNotExistInClusterException
@@ -24,6 +25,7 @@ from sunbeam.jobs.common import BaseStep, Result, ResultType
 from sunbeam.jobs.juju import CONTROLLER_MODEL
 
 LOG = logging.getLogger(__name__)
+snap = Snap()
 
 GHCR = "ghcr.io/openstack-snaps/{name}:{tag}"
 
@@ -87,7 +89,12 @@ def run_shell(cmd, check=True):
 def pull_image(machine_id, name, tag):
     image = GHCR.format(name=name, tag=tag)
 
-    cmd = SSH + [machine_id] + MICROK8S + ["ctr", "images", "pull", image]
+    https_proxy = snap.config.get("proxy.https_proxy")
+    cmd = SSH + [machine_id]
+    if https_proxy:
+        cmd.extend([f"https_proxy={https_proxy}"])
+    cmd.extend(MICROK8S)
+    cmd.extend(["ctr", "images", "pull", image])
     run(cmd)
 
 

--- a/sunbeam-python/sunbeam/commands/terraform.py
+++ b/sunbeam-python/sunbeam/commands/terraform.py
@@ -124,9 +124,9 @@ class TerraformHelper:
         timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
         tf_log = str(self.path / f"terraform-init-{timestamp}.log")
         os_env.update({"TF_LOG": "INFO", "TF_LOG_PATH": tf_log})
-        http_proxy = self.snap.config.get("proxy.http_proxy")
-        https_proxy = self.snap.config.get("proxy.https_proxy")
-        no_proxy = self.snap.config.get("proxy.no_proxy")
+        http_proxy = self.snap.config.get("proxy.http")
+        https_proxy = self.snap.config.get("proxy.https")
+        no_proxy = self.snap.config.get("proxy.no")
         if self.env:
             os_env.update(self.env)
         if self.backend:

--- a/sunbeam-python/sunbeam/hooks.py
+++ b/sunbeam-python/sunbeam/hooks.py
@@ -26,9 +26,9 @@ DEFAULT_CONFIG = {
     "juju.cloud.name": "sunbeam",
     "daemon.group": "snap_daemon",
     "daemon.debug": False,
-    "proxy.http_proxy": "",
-    "proxy.https_proxy": "",
-    "proxy.no_proxy": "",
+    "proxy.http": "",
+    "proxy.https": "",
+    "proxy.no": "",
 }
 
 OPTION_KEYS = set(k.split(".")[0] for k in DEFAULT_CONFIG.keys())


### PR DESCRIPTION
In situations where proxy is required, add https_proxy to pressed rocks so that proxy is used for image pull to github registry.