### PR TITLE
Add options to configure pull through caches

### DIFF
--- a/sunbeam-python/sunbeam/commands/bootstrap.py
+++ b/sunbeam-python/sunbeam/commands/bootstrap.py
@@ -51,7 +51,11 @@ from sunbeam.commands.microk8s import (
     DeployMicrok8sApplicationStep,
 )
 from sunbeam.commands.openstack import DeployControlPlaneStep
-from sunbeam.commands.rocks import ConfigureKubeletOptionsStep, PreseedRocksStep
+from sunbeam.commands.rocks import (
+    ConfigureKubeletOptionsStep,
+    ConfigurePullThroughCacheStep,
+    PreseedRocksStep,
+)
 from sunbeam.commands.terraform import TerraformHelper, TerraformInitStep
 from sunbeam.jobs.checks import (
     DaemonGroupCheck,
@@ -231,6 +235,7 @@ def bootstrap(
 
     if is_control_node:
         plan4.append(ConfigureKubeletOptionsStep(fqdn))
+        plan4.append(ConfigurePullThroughCacheStep(fqdn))
         plan4.append(PreseedRocksStep(fqdn))
         plan4.append(TerraformInitStep(tfhelper_openstack_deploy))
         plan4.append(

--- a/sunbeam-python/sunbeam/commands/node.py
+++ b/sunbeam-python/sunbeam/commands/node.py
@@ -53,7 +53,11 @@ from sunbeam.commands.microceph import (
 )
 from sunbeam.commands.microk8s import AddMicrok8sUnitStep, RemoveMicrok8sUnitStep
 from sunbeam.commands.openstack import OPENSTACK_MODEL
-from sunbeam.commands.rocks import ConfigureKubeletOptionsStep, PreseedRocksStep
+from sunbeam.commands.rocks import (
+    ConfigureKubeletOptionsStep,
+    ConfigurePullThroughCacheStep,
+    PreseedRocksStep,
+)
 from sunbeam.commands.terraform import TerraformHelper, TerraformInitStep
 from sunbeam.jobs.checks import (
     DaemonGroupCheck,
@@ -235,6 +239,7 @@ def join(
     if is_control_node:
         plan2.append(AddMicrok8sUnitStep(name, jhelper))
         plan2.append(ConfigureKubeletOptionsStep(name))
+        plan2.append(ConfigurePullThroughCacheStep(name))
         plan2.append(PreseedRocksStep(name))
 
     if is_storage_node:

--- a/sunbeam-python/sunbeam/hooks.py
+++ b/sunbeam-python/sunbeam/hooks.py
@@ -29,7 +29,10 @@ DEFAULT_CONFIG = {
     "proxy.http": "",
     "proxy.https": "",
     "proxy.no": "",
-    "cache.address": "",
+    "cache.ghcr-io": "",
+    "cache.docker-io": "",
+    "cache.quay-io": "",
+    "cache.k8s-gcr-io": "",
 }
 
 OPTION_KEYS = set(k.split(".")[0] for k in DEFAULT_CONFIG.keys())

--- a/sunbeam-python/sunbeam/hooks.py
+++ b/sunbeam-python/sunbeam/hooks.py
@@ -29,6 +29,7 @@ DEFAULT_CONFIG = {
     "proxy.http": "",
     "proxy.https": "",
     "proxy.no": "",
+    "cache.address": "",
 }
 
 OPTION_KEYS = set(k.split(".")[0] for k in DEFAULT_CONFIG.keys())


### PR DESCRIPTION
~Populating `cache.address` with a registry address will configure microk8s to pull from this registry when downloading images from ghcr.~

~`cache.address` should be configured with right address before the workshop is given, not to ask participants to configure it themselves.~

Configuring openstack snap with the cache options will configure microk8s to use cache registries to pull image from.
Cache options:
- cache.ghcr-io
- cache.docker-io
- cache.quay-io
- cache.k8s-gcr-io