### PR TITLE
os-hypervisor: read offers from openstack plan

### DIFF
--- a/cloud/etc/deploy-openstack-hypervisor/main.tf
+++ b/cloud/etc/deploy-openstack-hypervisor/main.tf
@@ -26,31 +26,9 @@ terraform {
 
 provider "juju" {}
 
-# Offers should be in the openstack control plane deployment plan but
-# need to be here for the moment due to
-# https://github.com/juju/terraform-provider-juju/issues/190
-resource "juju_offer" "rabbit_offer" {
-  model            = var.openstack_model
-  application_name = "rabbitmq"
-  endpoint         = "amqp"
-}
-
-resource "juju_offer" "keystone_offer" {
-  model            = var.openstack_model
-  application_name = "keystone"
-  endpoint         = "identity-credentials"
-}
-
-resource "juju_offer" "ca_offer" {
-  model            = var.openstack_model
-  application_name = "certificate-authority"
-  endpoint         = "certificates"
-}
-
-resource "juju_offer" "ovn_offer" {
-  model            = var.openstack_model
-  application_name = "ovn-relay"
-  endpoint         = "ovsdb-cms-relay"
+data "terraform_remote_state" "openstack" {
+  backend = var.openstack-state-backend
+  config  = var.openstack-state-config
 }
 
 resource "juju_application" "openstack-hypervisor" {
@@ -71,7 +49,7 @@ resource "juju_application" "openstack-hypervisor" {
 
 }
 
-resource "juju_integration" "hypervisor_amqp" {
+resource "juju_integration" "hypervisor-amqp" {
   model = var.hypervisor_model
 
   application {
@@ -80,11 +58,11 @@ resource "juju_integration" "hypervisor_amqp" {
   }
 
   application {
-    offer_url = juju_offer.rabbit_offer.url
+    offer_url = data.terraform_remote_state.openstack.outputs.rabbitmq-offer-url
   }
 }
 
-resource "juju_integration" "hypervisor_identity" {
+resource "juju_integration" "hypervisor-identity" {
   model = var.hypervisor_model
 
   application {
@@ -93,11 +71,11 @@ resource "juju_integration" "hypervisor_identity" {
   }
 
   application {
-    offer_url = juju_offer.keystone_offer.url
+    offer_url = data.terraform_remote_state.openstack.outputs.keystone-offer-url
   }
 }
 
-resource "juju_integration" "hypervisor_certs" {
+resource "juju_integration" "hypervisor-certs" {
   model = var.hypervisor_model
 
   application {
@@ -106,11 +84,11 @@ resource "juju_integration" "hypervisor_certs" {
   }
 
   application {
-    offer_url = juju_offer.ca_offer.url
+    offer_url = data.terraform_remote_state.openstack.outputs.ca-offer-url
   }
 }
 
-resource "juju_integration" "hypervisor_ovn" {
+resource "juju_integration" "hypervisor-ovn" {
   model = var.hypervisor_model
 
   application {
@@ -119,6 +97,6 @@ resource "juju_integration" "hypervisor_ovn" {
   }
 
   application {
-    offer_url = juju_offer.ovn_offer.url
+    offer_url = data.terraform_remote_state.openstack.outputs.ovn-relay-offer-url
   }
 }

--- a/cloud/etc/deploy-openstack-hypervisor/variables.tf
+++ b/cloud/etc/deploy-openstack-hypervisor/variables.tf
@@ -41,3 +41,11 @@ variable "hypervisor_model" {
   type        = string
 }
 
+variable "openstack-state-backend" {
+  description = "backend type used for openstack state"
+  type        = string
+  default     = "local"
+}
+variable "openstack-state-config" {
+  type = map(any)
+}

--- a/sunbeam-python/sunbeam/commands/bootstrap.py
+++ b/sunbeam-python/sunbeam/commands/bootstrap.py
@@ -242,7 +242,9 @@ def bootstrap(
     if is_compute_node:
         plan5.append(TerraformInitStep(tfhelper_hypervisor_deploy))
         plan5.append(
-            DeployHypervisorApplicationStep(tfhelper_hypervisor_deploy, jhelper)
+            DeployHypervisorApplicationStep(
+                tfhelper_hypervisor_deploy, tfhelper_openstack_deploy, jhelper
+            )
         )
         plan5.append(AddHypervisorUnitStep(fqdn, jhelper))
 

--- a/sunbeam-python/sunbeam/commands/hypervisor.py
+++ b/sunbeam-python/sunbeam/commands/hypervisor.py
@@ -47,6 +47,7 @@ class DeployHypervisorApplicationStep(BaseStep, JujuStepHelper):
     def __init__(
         self,
         tfhelper: TerraformHelper,
+        tfhelper_openstack: TerraformHelper,
         jhelper: JujuHelper,
     ):
         super().__init__(
@@ -54,6 +55,7 @@ class DeployHypervisorApplicationStep(BaseStep, JujuStepHelper):
             "Deploy openstack-hypervisor application onto cloud",
         )
         self.tfhelper = tfhelper
+        self.tfhelper_openstack = tfhelper_openstack
         self.jhelper = jhelper
         self.client = Client()
         self.hypervisor_model = CONTROLLER_MODEL.split("/")[-1]
@@ -81,11 +83,14 @@ class DeployHypervisorApplicationStep(BaseStep, JujuStepHelper):
         except ApplicationNotFoundException as e:
             LOG.debug(str(e))
 
+        openstack_backend_config = self.tfhelper_openstack.backend_config()
         self.tfhelper.write_tfvars(
             {
                 "hypervisor_model": self.hypervisor_model,
                 "openstack_model": self.openstack_model,
                 "machine_ids": machine_ids,
+                "openstack-state-backend": self.tfhelper_openstack.backend,
+                "openstack-state-config": openstack_backend_config,
             }
         )
         try:

--- a/sunbeam-python/sunbeam/commands/node.py
+++ b/sunbeam-python/sunbeam/commands/node.py
@@ -205,6 +205,13 @@ def join(
         LOG.debug(f"Updating {dst} from {src}...")
         shutil.copytree(src, dst, dirs_exist_ok=True)
 
+    tfhelper_openstack_deploy = TerraformHelper(
+        path=snap.paths.user_common / "etc" / "deploy-openstack",
+        plan="openstack-plan",
+        parallelism=1,
+        backend="http",
+        data_location=data_location,
+    )
     tfhelper_hypervisor_deploy = TerraformHelper(
         path=snap.paths.user_common / "etc" / "deploy-openstack-hypervisor",
         plan="hypervisor-plan",
@@ -246,7 +253,9 @@ def join(
         plan2.extend(
             [
                 TerraformInitStep(tfhelper_hypervisor_deploy),
-                DeployHypervisorApplicationStep(tfhelper_hypervisor_deploy, jhelper),
+                DeployHypervisorApplicationStep(
+                    tfhelper_hypervisor_deploy, tfhelper_openstack_deploy, jhelper
+                ),
                 AddHypervisorUnitStep(name, jhelper),
                 SetLocalHypervisorOptions(
                     name, jhelper, join_mode=True, preseed_file=preseed

--- a/sunbeam-python/tests/unit/sunbeam/commands/test_hypervisor.py
+++ b/sunbeam-python/tests/unit/sunbeam/commands/test_hypervisor.py
@@ -54,6 +54,7 @@ class TestDeployHypervisorStep(unittest.TestCase):
         self.client.start()
         self.jhelper = AsyncMock()
         self.tfhelper = Mock(path=Path())
+        self.tfhelper_openstack = Mock(output=Mock(return_value={}))
 
     def tearDown(self):
         self.client.stop()
@@ -63,14 +64,18 @@ class TestDeployHypervisorStep(unittest.TestCase):
             "not found"
         )
 
-        step = DeployHypervisorApplicationStep(self.tfhelper, self.jhelper)
+        step = DeployHypervisorApplicationStep(
+            self.tfhelper, self.tfhelper_openstack, self.jhelper
+        )
         result = step.is_skip()
 
         self.jhelper.get_application.assert_called_once()
         assert result.result_type == ResultType.COMPLETED
 
     def test_is_skip_app_already_deployed(self):
-        step = DeployHypervisorApplicationStep(self.tfhelper, self.jhelper)
+        step = DeployHypervisorApplicationStep(
+            self.tfhelper, self.tfhelper_openstack, self.jhelper
+        )
         result = step.is_skip()
 
         self.jhelper.get_application.assert_called_once()
@@ -81,7 +86,9 @@ class TestDeployHypervisorStep(unittest.TestCase):
             "not found"
         )
 
-        step = DeployHypervisorApplicationStep(self.tfhelper, self.jhelper)
+        step = DeployHypervisorApplicationStep(
+            self.tfhelper, self.tfhelper_openstack, self.jhelper
+        )
         result = step.run()
 
         self.tfhelper.write_tfvars.assert_called_once()
@@ -91,7 +98,9 @@ class TestDeployHypervisorStep(unittest.TestCase):
     def test_run_tf_apply_failed(self):
         self.tfhelper.apply.side_effect = TerraformException("apply failed...")
 
-        step = DeployHypervisorApplicationStep(self.tfhelper, self.jhelper)
+        step = DeployHypervisorApplicationStep(
+            self.tfhelper, self.tfhelper_openstack, self.jhelper
+        )
         result = step.run()
 
         self.tfhelper.apply.assert_called_once()
@@ -101,7 +110,9 @@ class TestDeployHypervisorStep(unittest.TestCase):
     def test_run_waiting_timed_out(self):
         self.jhelper.wait_application_ready.side_effect = TimeoutException("timed out")
 
-        step = DeployHypervisorApplicationStep(self.tfhelper, self.jhelper)
+        step = DeployHypervisorApplicationStep(
+            self.tfhelper, self.tfhelper_openstack, self.jhelper
+        )
         result = step.run()
 
         self.jhelper.wait_application_ready.assert_called_once()


### PR DESCRIPTION
Data Source for offers has been added in juju provider 0.7.0, move the offer creation to sunbeam terraform. Read the offers from the plan stored in microcluster.

Depends-On: https://github.com/openstack-snaps/sunbeam-terraform/pull/25