### PR TITLE
Fail nicely when demo-setup plan is missing

### DIFF
--- a/sunbeam-python/sunbeam/commands/launch.py
+++ b/sunbeam-python/sunbeam/commands/launch.py
@@ -63,6 +63,10 @@ def launch(image_name: str, key: str, name: Optional[str] = None) -> None:
 
         admin_auth_info = retrieve_admin_credentials(jhelper, OPENSTACK_MODEL)
 
+        terraform_plan_location = snap.paths.user_common / "etc" / "demo-setup"
+        if not terraform_plan_location.exists():
+            raise click.ClickException("Please run `sunbeam configure` first")
+
         try:
             terraform = str(snap.paths.snap / "bin" / "terraform")
             cmd = [terraform, "output", "-json"]
@@ -72,7 +76,7 @@ def launch(image_name: str, key: str, name: Optional[str] = None) -> None:
                 capture_output=True,
                 text=True,
                 check=True,
-                cwd=snap.paths.user_common / "etc" / "demo-setup",
+                cwd=terraform_plan_location,
             )
             tf_output = json.loads(process.stdout)
 


### PR DESCRIPTION
The launch command failed with `Error: [Errno 2] No such file or directory:
PosixPath('/home/ubuntu/snap/openstack/common/etc/demo-setup')` when attempting to run a process in this path.