### PR TITLE
Add explanation when clusterd socket is missing

### DIFF
--- a/sunbeam-python/sunbeam/clusterd/service.py
+++ b/sunbeam-python/sunbeam/clusterd/service.py
@@ -119,7 +119,13 @@ class BaseService(ABC):
             response = self.__session.request(method=method, url=url, **kwargs)
             LOG.debug("Response(%s) = %s", response, response.text)
         except ConnectionError as e:
-            raise ClusterServiceUnavailableException(str(e))
+            msg = str(e)
+            if "FileNotFoundError" in msg:
+                raise ClusterServiceUnavailableException(
+                    "Sunbeam Cluster socket not found, is clusterd running ?"
+                    " Check with 'snap services openstack.clusterd'",
+                ) from e
+            raise ClusterServiceUnavailableException(msg)
 
         try:
             response.raise_for_status()


### PR DESCRIPTION
When clusterd is stopped, the socket is missing from the FS, add details about the error and how to diagnose.