### PR TITLE
Switch to using stable channels.

### DIFF
--- a/cloud/etc/deploy-openstack-hypervisor/variables.tf
+++ b/cloud/etc/deploy-openstack-hypervisor/variables.tf
@@ -22,13 +22,13 @@ variable "machine_ids" {
 variable "snap_channel" {
   description = "Snap channel to deploy openstack-hypervisor snap from"
   type        = string
-  default     = "2023.1/edge"
+  default     = "2023.1/stable"
 }
 
 variable "charm_channel" {
   description = "Charm channel to deploy openstack-hypervisor charm from"
   type        = string
-  default     = "2023.1/edge"
+  default     = "2023.1/stable"
 }
 
 variable "openstack_model" {

--- a/sunbeam-python/sunbeam/commands/openstack.py
+++ b/sunbeam-python/sunbeam/commands/openstack.py
@@ -191,8 +191,8 @@ class DeployControlPlaneStep(BaseStep, JujuStepHelper):
         tfvars = {
             "model": self.model,
             # Make these channel options configurable by the user
-            "openstack-channel": "2023.1/edge",
-            "ovn-channel": "23.03/edge",
+            "openstack-channel": "2023.1/stable",
+            "ovn-channel": "23.03/stable",
             "cloud": self.cloud,
             "credential": f"{self.cloud}{CREDENTIAL_SUFFIX}",
             "config": {"workload-storage": MICROK8S_DEFAULT_STORAGECLASS},


### PR DESCRIPTION
As part of the first stable release, switch to using the stable channels for openstack and ovn charms.

Update the openstack-hypervisor terraform plan to default to using stable channels for charm and snap.