### PR TITLE
Switch charm channels back to edge for development

### DIFF
--- a/cloud/etc/deploy-openstack-hypervisor/variables.tf
+++ b/cloud/etc/deploy-openstack-hypervisor/variables.tf
@@ -22,13 +22,13 @@ variable "machine_ids" {
 variable "snap_channel" {
   description = "Snap channel to deploy openstack-hypervisor snap from"
   type        = string
-  default     = "2023.1/stable"
+  default     = "2023.1/edge"
 }
 
 variable "charm_channel" {
   description = "Charm channel to deploy openstack-hypervisor charm from"
   type        = string
-  default     = "2023.1/stable"
+  default     = "2023.1/edge"
 }
 
 variable "openstack_model" {

--- a/sunbeam-python/sunbeam/commands/openstack.py
+++ b/sunbeam-python/sunbeam/commands/openstack.py
@@ -191,8 +191,8 @@ class DeployControlPlaneStep(BaseStep, JujuStepHelper):
         tfvars = {
             "model": self.model,
             # Make these channel options configurable by the user
-            "openstack-channel": "2023.1/stable",
-            "ovn-channel": "23.03/stable",
+            "openstack-channel": "2023.1/edge",
+            "ovn-channel": "23.03/edge",
             "cloud": self.cloud,
             "credential": f"{self.cloud}{CREDENTIAL_SUFFIX}",
             "config": {"workload-storage": MICROK8S_DEFAULT_STORAGECLASS},


### PR DESCRIPTION
Reset default charms back to edge channels now that the stable/2023.1 branch exists to manage candidate+ channels on the snap store.