### PR TITLE
Include mirrored providers for offline installation

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -150,8 +150,13 @@ parts:
     source: cloud/
     override-build: |
       craftctl default
-      cd $SNAPCRAFT_PART_INSTALL/etc/deploy-microk8s
-      $SNAPCRAFT_STAGE/bin/terraform providers mirror $SNAPCRAFT_STAGE/terraform-providers
+      for plan in $(ls $SNAPCRAFT_PART_INSTALL/etc/);
+      do
+        cd $SNAPCRAFT_PART_INSTALL/etc/$plan
+        $SNAPCRAFT_STAGE/bin/terraform init
+        $SNAPCRAFT_STAGE/bin/terraform providers mirror $SNAPCRAFT_PRIME/usr/share/terraform-providers
+        rm -rf ./.terraform
+      done
 
   terraform-openstack-plan:
     after: [terraform]
@@ -165,7 +170,7 @@ parts:
       craftctl default
       cd $SNAPCRAFT_PART_INSTALL
       $SNAPCRAFT_STAGE/bin/terraform init
-      $SNAPCRAFT_STAGE/bin/terraform providers mirror $SNAPCRAFT_STAGE/terraform-providers
+      $SNAPCRAFT_STAGE/bin/terraform providers mirror $SNAPCRAFT_PRIME/usr/share/terraform-providers
       rm -rf $SNAPCRAFT_PART_INSTALL/.terraform
 
   wrappers:

--- a/sunbeam-python/sunbeam/commands/terraform.py
+++ b/sunbeam-python/sunbeam/commands/terraform.py
@@ -46,6 +46,14 @@ terraform {
 }
 """
 
+terraform_rc_template = """
+provider_installation {
+  filesystem_mirror {
+    path    = "$snap_path/usr/share/terraform-providers"
+  }
+}
+"""
+
 
 class TerraformException(Exception):
     """Terraform related exceptions"""
@@ -111,6 +119,16 @@ class TerraformHelper:
         with filepath.open("w") as tfvars:
             tfvars.write(json.dumps(vars))
 
+    def write_terraformrc(self) -> None:
+        """Write .terraformrc file"""
+        terraform_rc = self.snap.paths.user_data / ".terraformrc"
+        with terraform_rc.open(mode="w") as file:
+            file.write(
+                Template(terraform_rc_template).safe_substitute(
+                    {"snap_path": self.snap.paths.snap}
+                )
+            )
+
     def update_juju_provider_credentials(self) -> dict:
         os_env = {}
         if self.data_location:
@@ -139,6 +157,7 @@ class TerraformHelper:
             self.write_backend_tf()
         if self.data_location:
             os_env.update(self.update_juju_provider_credentials())
+        self.write_terraformrc()
 
         try:
             cmd = [self.terraform, "init", "-upgrade", "-no-color"]


### PR DESCRIPTION
Include mirrored providers in the resulting snap, and configure terraform to use them.