### PR TITLE
Enhance retrieving fqdn logic

### DIFF
--- a/sunbeam-python/sunbeam/commands/bootstrap.py
+++ b/sunbeam-python/sunbeam/commands/bootstrap.py
@@ -67,6 +67,7 @@ from sunbeam.jobs.checks import (
     JujuSnapCheck,
     LocalShareCheck,
     SshKeysConnectedCheck,
+    VerifyHypervisorHostnameCheck,
 )
 from sunbeam.jobs.common import (
     Role,
@@ -165,6 +166,11 @@ def bootstrap(
     preflight_checks.append(SshKeysConnectedCheck())
     preflight_checks.append(DaemonGroupCheck())
     preflight_checks.append(LocalShareCheck())
+    if is_compute_node:
+        hypervisor_hostname = utils.get_hypervisor_hostname()
+        preflight_checks.append(
+            VerifyHypervisorHostnameCheck(fqdn, hypervisor_hostname)
+        )
 
     run_preflight_checks(preflight_checks, console)
 

--- a/sunbeam-python/sunbeam/commands/node.py
+++ b/sunbeam-python/sunbeam/commands/node.py
@@ -40,11 +40,9 @@ from sunbeam.commands.hypervisor import (
 )
 from sunbeam.commands.juju import (
     AddJujuMachineStep,
-    JujuLoginStep,
-)  # RemoveJujuUserStep,
-from sunbeam.commands.juju import (
     CreateJujuUserStep,
     JujuGrantModelAccessStep,
+    JujuLoginStep,
     RegisterJujuUserStep,
     RemoveJujuMachineStep,
     SaveJujuUserLocallyStep,

--- a/sunbeam-python/sunbeam/commands/node.py
+++ b/sunbeam-python/sunbeam/commands/node.py
@@ -62,6 +62,7 @@ from sunbeam.jobs.checks import (
     LocalShareCheck,
     SshKeysConnectedCheck,
     VerifyFQDNCheck,
+    VerifyHypervisorHostnameCheck,
 )
 from sunbeam.jobs.common import (
     ResultType,
@@ -189,6 +190,11 @@ def join(
     preflight_checks.append(SshKeysConnectedCheck())
     preflight_checks.append(DaemonGroupCheck())
     preflight_checks.append(LocalShareCheck())
+    if is_compute_node:
+        hypervisor_hostname = utils.get_hypervisor_hostname()
+        preflight_checks.append(
+            VerifyHypervisorHostnameCheck(name, hypervisor_hostname)
+        )
 
     run_preflight_checks(preflight_checks, console)
 

--- a/sunbeam-python/sunbeam/jobs/checks.py
+++ b/sunbeam-python/sunbeam/jobs/checks.py
@@ -215,3 +215,25 @@ class VerifyFQDNCheck(Check):
                 return False
 
         return True
+
+
+class VerifyHypervisorHostnameCheck(Check):
+    """Check if Hypervisor Hostname is same as FQDN."""
+
+    def __init__(self, fqdn, hypervisor_hostname):
+        super().__init__(
+            "Check for Hypervisor Hostname",
+            "Checking if Hypervisor Hostname is same as FQDN",
+        )
+        self.fqdn = fqdn
+        self.hypervisor_hostname = hypervisor_hostname
+
+    def run(self) -> bool:
+        if self.fqdn == self.hypervisor_hostname:
+            return True
+
+        self.message = (
+            "Host FQDN and Hypervisor hostname perceived by libvirt are different, "
+            "check `hostname -f` and `/etc/hosts` file"
+        )
+        return False

--- a/sunbeam-python/sunbeam/utils.py
+++ b/sunbeam-python/sunbeam/utils.py
@@ -49,7 +49,38 @@ def is_nic_up(iface_name: str) -> bool:
 
 def get_fqdn() -> str:
     """Get FQDN of the machine"""
-    return socket.getfqdn()
+    # If the fqdn returned by this function and from libvirt are different,
+    # the hypervisor name and the one registered in OVN will be different
+    # which leads to port binding errors,
+    # see https://bugs.launchpad.net/snap-openstack/+bug/2023931
+
+    # Use same logic used by libvirt
+    # https://github.com/libvirt/libvirt/blob/a5bf2c4bf962cfb32f9137be5f0ba61cdd14b0e7/src/util/virutil.c#L406
+    hostname = socket.gethostname()
+    if "." in hostname:
+        return hostname
+
+    addrinfo = socket.getaddrinfo(
+        hostname, None, family=socket.AF_UNSPEC, flags=socket.AI_CANONNAME
+    )
+    for addr in addrinfo:
+        fqdn = addr[3]
+        if fqdn and fqdn != "localhost":
+            return fqdn
+
+    # Deviation from libvirt logic
+    # Try to get fqdn from IP address as a last resort
+    ip = get_local_ip_by_default_route()
+    try:
+        fqdn = socket.getfqdn(socket.gethostbyaddr(ip)[0])
+        if fqdn != "localhost":
+            return fqdn
+    except Exception as e:
+        LOG.debug("Ignoring error in getting FQDN")
+        LOG.debug(e, exc_info=True)
+
+    # return hostname if fqdn is localhost
+    return hostname
 
 
 def get_local_ip_by_default_route() -> str:

--- a/sunbeam-python/tests/unit/sunbeam/test_utils.py
+++ b/sunbeam-python/tests/unit/sunbeam/test_utils.py
@@ -78,9 +78,38 @@ class TestUtils:
         assert not utils.is_nic_up("eth3")
 
     def test_get_fqdn(self, mocker):
+        gethostname = mocker.patch("sunbeam.utils.socket.gethostname")
+        gethostname.return_value = "myhost"
+        getaddrinfo = mocker.patch("sunbeam.utils.socket.getaddrinfo")
+        getaddrinfo.return_value = [(2, 1, 6, "myhost.local", ("10.5.3.44", 0))]
+        assert utils.get_fqdn() == "myhost.local"
+
+    def test_get_fqdn_when_gethostname_has_dot(self, mocker):
+        gethostname = mocker.patch("sunbeam.utils.socket.gethostname")
+        gethostname.return_value = "myhost.local"
+        assert utils.get_fqdn() == "myhost.local"
+
+    def test_get_fqdn_when_getaddrinfo_has_localhost_as_fqdn(self, mocker):
+        gethostname = mocker.patch("sunbeam.utils.socket.gethostname")
+        gethostname.return_value = "myhost"
+        getaddrinfo = mocker.patch("sunbeam.utils.socket.getaddrinfo")
+        getaddrinfo.return_value = [(2, 1, 6, "localhost", ("10.5.3.44", 0))]
+        local_ip = mocker.patch("sunbeam.utils.get_local_ip_by_default_route")
+        local_ip.return_value = "127.0.0.1"
         getfqdn = mocker.patch("sunbeam.utils.socket.getfqdn")
         getfqdn.return_value = "myhost.local"
         assert utils.get_fqdn() == "myhost.local"
+
+    def test_get_fqdn_when_getfqdn_returns_localhost(self, mocker):
+        gethostname = mocker.patch("sunbeam.utils.socket.gethostname")
+        gethostname.return_value = "myhost"
+        getaddrinfo = mocker.patch("sunbeam.utils.socket.getaddrinfo")
+        getaddrinfo.return_value = [(2, 1, 6, "localhost", ("10.5.3.44", 0))]
+        local_ip = mocker.patch("sunbeam.utils.get_local_ip_by_default_route")
+        local_ip.return_value = "127.0.0.1"
+        getfqdn = mocker.patch("sunbeam.utils.socket.getfqdn")
+        getfqdn.return_value = "localhost"
+        assert utils.get_fqdn() == "myhost"
 
     def test_get_local_ip_by_default_route(self, mocker, ifaddresses):
         gateways = mocker.patch("sunbeam.utils.netifaces.gateways")


### PR DESCRIPTION
Geting FQDN is tricky sometimes returning localhost and sometimes one different from what livirt provides, see bug [1]

Update fqdn logic to follow the procedure mentioned in libvirt [2]. If the result is still localhost, try to get fqdn using ip address. Use hostname as last resort as the sunbeam cluster node will be idenified by this and it should not be localhost.

[1] https://bugs.launchpad.net/snap-openstack/+bug/2023931
[2] https://github.com/libvirt/libvirt/blob/a5bf2c4bf962cfb32f9137be5f0ba61cdd14b0e7/src/util/virutil.c#L406