### PR TITLE
Remove lstrip on inspect plans

### DIFF
--- a/sunbeam-python/sunbeam/commands/inspect.py
+++ b/sunbeam-python/sunbeam/commands/inspect.py
@@ -101,7 +101,7 @@ def plans(format: str):
         table.add_column("Locked", justify="center")
         for plan in plans:
             table.add_row(
-                plan.lstrip("tfstate-"),
+                plan,
                 "x" if plan in locks else "",
             )
         console.print(table)


### PR DESCRIPTION
The lstrip is actually done in microcluster, it should not be done on python side.