### PR TITLE
Use fallback for determining interface for local ip

### DIFF
--- a/sunbeam-python/sunbeam/utils.py
+++ b/sunbeam-python/sunbeam/utils.py
@@ -20,7 +20,7 @@ import re
 import socket
 import sys
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 import click
 import netifaces
@@ -93,6 +93,58 @@ def get_fqdn() -> str:
     return socket.gethostname()
 
 
+def _get_default_gw_iface_fallback() -> Optional[str]:
+    """Returns the default gateway interface.
+
+    Parses the /proc/net/route table to determine the interface with a default
+    route. The interface with the default route will have a destination of 0x000000,
+    a mask of 0x000000 and will have flags indicating RTF_GATEWAY and RTF_UP.
+
+    :return Optional[str, None]: the name of the interface the default gateway or
+            None if one cannot be found.
+    """
+    # see include/uapi/linux/route.h in kernel source for more explanation
+    RTF_UP = 0x1  # noqa - route is usable
+    RTF_GATEWAY = 0x2  # noqa - destination is a gateway
+
+    iface = None
+    with open("/proc/net/route", "r") as f:
+        contents = [line.strip() for line in f.readlines() if line.strip()]
+        print(contents)
+
+        entries = []
+        # First line is a header line of the table contents. Note, we skip blank entries
+        # by default there's an extra column due to an extra \t character for the table
+        # contents to line up. This is parsing the /proc/net/route and creating a set of
+        # entries. Each entry is a dict where the keys are table header and the values
+        # are the values in the table rows.
+        header = [col.strip().lower() for col in contents[0].split("\t") if col]
+        for row in contents[1:]:
+            cells = [col.strip() for col in row.split("\t") if col]
+            entries.append(dict(zip(header, cells)))
+
+        def is_up(flags: str) -> bool:
+            return int(flags, 16) & RTF_UP == RTF_UP
+
+        def is_gateway(flags: str) -> bool:
+            return int(flags, 16) & RTF_GATEWAY == RTF_GATEWAY
+
+        # Check each entry to see if it has the default gateway. The default gateway
+        # will have destination and mask set to 0x00, will be up and is noted as a
+        # gateway.
+        for entry in entries:
+            if int(entry.get("destination", 0xFF), 16) != 0:
+                continue
+            if int(entry.get("mask", 0xFF), 16) != 0:
+                continue
+            flags = entry.get("flags", 0x00)
+            if is_up(flags) and is_gateway(flags):
+                iface = entry.get("iface", None)
+                break
+
+    return iface
+
+
 def get_ifaddresses_by_default_route() -> dict:
     """Get address configuration from interface associated with default gateway."""
     interface = "lo"
@@ -100,8 +152,14 @@ def get_ifaddresses_by_default_route() -> dict:
     netmask = "255.0.0.0"
 
     # TOCHK: Gathering only IPv4
-    if "default" in netifaces.gateways():
+    default_gateways = netifaces.gateways().get("default", {})
+    if default_gateways and netifaces.AF_INET in default_gateways:
         interface = netifaces.gateways()["default"][netifaces.AF_INET][1]
+    else:
+        # There are some cases where netifaces doesn't return the machine's default
+        # gateway, but it does exist. Let's check the /proc/net/route table to see
+        # if we can find the proper gateway.
+        interface = _get_default_gw_iface_fallback() or "lo"
 
     ip_list = netifaces.ifaddresses(interface)[netifaces.AF_INET]
     if len(ip_list) > 0 and "addr" in ip_list[0]:


### PR DESCRIPTION
In some cases, the netifaces does not properly detect the default gateway for the node and returns an empty dict. However, there is a default gateway actually set. This adds a fallback path to parse the contents of the /proc/net/route table and determine which interface to use based on which flags are set on the routes.