### PR TITLE
Exit on is_skip failure

### DIFF
--- a/sunbeam-python/sunbeam/commands/clusterd.py
+++ b/sunbeam-python/sunbeam/commands/clusterd.py
@@ -66,6 +66,8 @@ class ClusterInitStep(BaseStep):
                 return Result(ResultType.SKIPPED)
         except ClusterServiceUnavailableException as e:
             LOG.debug(e)
+            if "Sunbeam Cluster not initialized" in str(e):
+                return Result(ResultType.COMPLETED)
             return Result(ResultType.FAILED, str(e))
 
         return Result(ResultType.COMPLETED)
@@ -159,6 +161,8 @@ class ClusterJoinNodeStep(BaseStep):
                 return Result(ResultType.SKIPPED)
         except ClusterServiceUnavailableException as e:
             LOG.debug(e)
+            if "Sunbeam Cluster not initialized" in str(e):
+                return Result(ResultType.COMPLETED)
             return Result(ResultType.FAILED, str(e))
 
         return Result(ResultType.COMPLETED)

--- a/sunbeam-python/sunbeam/jobs/common.py
+++ b/sunbeam-python/sunbeam/jobs/common.py
@@ -235,6 +235,9 @@ def run_plan(plan: List[BaseStep], console: Console) -> dict:
                 LOG.debug(f"Skipping step {step.name}")
                 continue
 
+            if skip_result.result_type == ResultType.FAILED:
+                raise click.ClickException(skip_result.message)
+
             LOG.debug(f"Running step {step.name}")
             result = step.run(status)
             results[step.__class__.__name__] = result


### PR DESCRIPTION
Previously, `is_skip` checks did not abort the installation when they failed.