### PR TITLE
Add error message to JujuAccountNotFound exception

### DIFF
--- a/sunbeam-python/sunbeam/jobs/juju.py
+++ b/sunbeam-python/sunbeam/jobs/juju.py
@@ -144,7 +144,9 @@ class JujuAccount:
             with data_file.open() as file:
                 return JujuAccount(**yaml.safe_load(file))
         except FileNotFoundError as e:
-            raise JujuAccountNotFound() from e
+            raise JujuAccountNotFound(
+                "Juju user account not found, is node part of sunbeam cluster yet?"
+            ) from e
 
     def write(self, data_location: Path):
         data_file = data_location / ACCOUNT_FILE


### PR DESCRIPTION
Currently JujuAccountNotFound exception doesnot have any error message and so it just prints Error in the console. Add appropriate error message.