### PR TITLE
terraform: run with default parallelism

### DIFF
--- a/sunbeam-python/sunbeam/commands/bootstrap.py
+++ b/sunbeam-python/sunbeam/commands/bootstrap.py
@@ -204,35 +204,30 @@ def bootstrap(
     tfhelper = TerraformHelper(
         path=snap.paths.user_common / "etc" / "deploy-microk8s",
         plan="microk8s-plan",
-        parallelism=1,
         backend="http",
         data_location=data_location,
     )
     tfhelper_openstack_deploy = TerraformHelper(
         path=snap.paths.user_common / "etc" / "deploy-openstack",
         plan="openstack-plan",
-        parallelism=1,
         backend="http",
         data_location=data_location,
     )
     tfhelper_hypervisor_deploy = TerraformHelper(
         path=snap.paths.user_common / "etc" / "deploy-openstack-hypervisor",
         plan="hypervisor-plan",
-        parallelism=1,
         backend="http",
         data_location=data_location,
     )
     tfhelper_microceph_deploy = TerraformHelper(
         path=snap.paths.user_common / "etc" / "deploy-microceph",
         plan="microceph-plan",
-        parallelism=1,
         backend="http",
         data_location=data_location,
     )
     tfhelper_sunbeam_machine = TerraformHelper(
         path=snap.paths.user_common / "etc" / "deploy-sunbeam-machine",
         plan="sunbeam-machine-plan",
-        parallelism=1,
         backend="http",
         data_location=data_location,
     )

--- a/sunbeam-python/sunbeam/commands/configure.py
+++ b/sunbeam-python/sunbeam/commands/configure.py
@@ -757,7 +757,6 @@ def configure(
         path=snap.paths.user_common / "etc" / "demo-setup",
         env=admin_credentials,
         plan="demo-setup",
-        parallelism=1,
         backend="http",
         data_location=data_location,
     )

--- a/sunbeam-python/sunbeam/commands/node.py
+++ b/sunbeam-python/sunbeam/commands/node.py
@@ -216,14 +216,12 @@ def join(
     tfhelper_openstack_deploy = TerraformHelper(
         path=snap.paths.user_common / "etc" / "deploy-openstack",
         plan="openstack-plan",
-        parallelism=1,
         backend="http",
         data_location=data_location,
     )
     tfhelper_hypervisor_deploy = TerraformHelper(
         path=snap.paths.user_common / "etc" / "deploy-openstack-hypervisor",
         plan="hypervisor-plan",
-        parallelism=1,
         backend="http",
         data_location=data_location,
     )

--- a/sunbeam-python/sunbeam/commands/plugins/pro.py
+++ b/sunbeam-python/sunbeam/commands/plugins/pro.py
@@ -167,7 +167,6 @@ def enable_pro(token: str) -> None:
     tfhelper = TerraformHelper(
         path=snap.paths.user_common / "etc" / tfplan,
         plan="ubuntu-pro-plan",
-        parallelism=1,
         backend="http",
         data_location=data_location,
     )
@@ -201,7 +200,6 @@ def disable_pro() -> None:
     tfhelper = TerraformHelper(
         path=snap.paths.user_common / "etc" / tfplan,
         plan="ubuntu-pro-plan",
-        parallelism=1,
         backend="http",
         data_location=data_location,
     )

--- a/sunbeam-python/sunbeam/commands/resize.py
+++ b/sunbeam-python/sunbeam/commands/resize.py
@@ -47,7 +47,6 @@ def resize(topology: str, force: bool = False) -> None:
     tfhelper = TerraformHelper(
         path=snap.paths.user_common / "etc" / tfplan,
         plan="openstack-plan",
-        parallelism=1,
         backend="http",
         data_location=data_location,
     )


### PR DESCRIPTION
parallelism=1 was a workaround for a bug in Juju which has since been resolved - use default level of parallelism to reduce the amount of time taken to apply terraform plans.