### PR TITLE
Always log to disk

### DIFF
--- a/sunbeam-python/sunbeam/commands/inspect.py
+++ b/sunbeam-python/sunbeam/commands/inspect.py
@@ -17,6 +17,7 @@ import datetime
 import logging
 import tarfile
 import tempfile
+import shutil
 from pathlib import Path
 
 import click
@@ -76,7 +77,14 @@ def inspect(ctx: click.Context) -> None:
 
         run_plan(plan, console)
 
-        with tarfile.open(dump_file, "w:gz") as tar:
+        with console.status("[bold green]Copying logs..."):
+            log_dir = snap.paths.user_common / "logs"
+            if log_dir.exists():
+                shutil.copytree(log_dir, Path(tmpdirname) / "logs")
+
+        with console.status("[bold green]Creating tarball..."), tarfile.open(
+            dump_file, "w:gz"
+        ) as tar:
             tar.add(tmpdirname, arcname="./")
 
     console.print(f"[green]Output file written to {dump_file}[/green]")

--- a/sunbeam-python/sunbeam/log.py
+++ b/sunbeam-python/sunbeam/log.py
@@ -12,19 +12,21 @@
 # implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 import logging
 import sys
+from datetime import datetime
 from pathlib import Path
-from typing import Union
+from typing import Optional, Union
 
 from rich.logging import RichHandler
 
+MAX_LOG_FILES = 10
 
-def setup_root_logging():
+
+def setup_root_logging(logfile: Optional[Path] = None):
     """Sets up the root logging level for the application.
 
-    By default, console logging will be turned off and file level logging
+    By default, console logging will be turned off and level logging
     will be turned to INFO level of trace.
 
     The logging is configured based upon execution context, such that
@@ -65,6 +67,18 @@ def setup_root_logging():
         handler.setFormatter(logging.Formatter("%(message)s", datefmt="[%X]"))
         logger.addHandler(handler)
 
+    if logfile:
+        handler = logging.FileHandler(logfile)
+        handler.setLevel(logging.DEBUG)
+        handler.setFormatter(
+            logging.Formatter(
+                "%(asctime)s,%(msecs)d %(name)s %(levelname)s %(message)s",
+                datefmt="%H:%M:%S",
+            )
+        )
+        logger.addHandler(handler)
+        logger.debug(f"Logging to {str(logfile)!r}")
+
 
 def setup_logging(logfile: Union[Path, str]) -> None:
     """Sets up the logging for the specified logfile.
@@ -81,3 +95,20 @@ def setup_logging(logfile: Union[Path, str]) -> None:
         datefmt="%H:%M:%S",
         level=logging.DEBUG,
     )
+
+
+def prepare_logfile(path: Path, name: str) -> Path:
+    """Remove older log files and return a logfile name for current execution.
+
+    :param path: Path to the logs directoy
+    :param name: name of the logfile
+    """
+    path.mkdir(mode=0o750, exist_ok=True)
+    limit = MAX_LOG_FILES - 1
+    present_files = list(path.glob(f"{name}-*.log"))
+    if len(present_files) > limit:
+        for fpath in sorted(present_files)[:-limit]:
+            fpath.unlink(missing_ok=True)
+
+    logfile = path / f"{name}-{datetime.now():%Y%m%d-%H%M%S.%f}.log"
+    return logfile

--- a/sunbeam-python/sunbeam/main.py
+++ b/sunbeam-python/sunbeam/main.py
@@ -16,6 +16,7 @@
 import logging
 
 import click
+from snaphelpers import Snap
 
 from sunbeam import log
 from sunbeam.commands import bootstrap as bootstrap_cmds
@@ -71,7 +72,9 @@ def disable(ctx):
 
 
 def main():
-    log.setup_root_logging()
+    snap = Snap()
+    logfile = log.prepare_logfile(snap.paths.user_common / "logs", "sunbeam")
+    log.setup_root_logging(logfile)
     cli.add_command(prepare_node_cmds.prepare_node_script)
     cli.add_command(configure_cmds.configure)
     cli.add_command(generate_cloud_config_cmds.cloud_config)


### PR DESCRIPTION
This change allows to always output debug logs to disk at: $HOME/snap/openstack/common/logs, helping users reading debug logs when an issue arised with their installation.

Including debug logs to inspect report.