### PR TITLE
Cleanup output for fallback default routes

### DIFF
--- a/sunbeam-python/sunbeam/utils.py
+++ b/sunbeam-python/sunbeam/utils.py
@@ -110,7 +110,7 @@ def _get_default_gw_iface_fallback() -> Optional[str]:
     iface = None
     with open("/proc/net/route", "r") as f:
         contents = [line.strip() for line in f.readlines() if line.strip()]
-        print(contents)
+        logging.debug(contents)
 
         entries = []
         # First line is a header line of the table contents. Note, we skip blank entries


### PR DESCRIPTION
Commit 24ea5a7 introduced fallback logic for when the default route cannot be determined using netifaces. However, this also brought with it an undesired side-effect of printing the output of /proc/net/route to the console. This commit changes it to a debug statement in the logs rather than the console itself.