### PR TITLE
Update controller endpoint when DB has empty list

### DIFF
--- a/sunbeam-python/sunbeam/commands/clusterd.py
+++ b/sunbeam-python/sunbeam/commands/clusterd.py
@@ -352,6 +352,13 @@ class ClusterUpdateJujuControllerStep(BaseStep, JujuStepHelper):
             self.networks = variables.get("bootstrap", {}).get("management_cidr")
             juju_controller = JujuController.load(self.client)
             LOG.debug(f"Controller(s) present at: {juju_controller.api_endpoints}")
+            if not juju_controller.api_endpoints:
+                LOG.debug(
+                    "Controller endpoints are empty in database, so update the "
+                    "database by getting controller endpoints again"
+                )
+                return Result(ResultType.COMPLETED)
+
             if juju_controller.api_endpoints == self.filter_ips(
                 juju_controller.api_endpoints, self.networks
             ):

--- a/sunbeam-python/sunbeam/commands/inspect.py
+++ b/sunbeam-python/sunbeam/commands/inspect.py
@@ -15,9 +15,9 @@
 
 import datetime
 import logging
+import shutil
 import tarfile
 import tempfile
-import shutil
 from pathlib import Path
 
 import click


### PR DESCRIPTION
When user inputs wrong management_cidr, the controller api endpoints are updated with empty list in cluster database. Rerunning the bootstrap with proper
management cidr only reads the endpoints from the
cluster DB which is empty list and further connectivity to juju is broken.
Do not skip ClusterUpdateJujuController Step if
api endpoints are empty.