### PR TITLE
Add default stream handler when console is disabled

### DIFF
--- a/sunbeam-python/sunbeam/log.py
+++ b/sunbeam-python/sunbeam/log.py
@@ -66,6 +66,10 @@ def setup_root_logging(logfile: Optional[Path] = None):
         handler.setLevel(logging.DEBUG)
         handler.setFormatter(logging.Formatter("%(message)s", datefmt="[%X]"))
         logger.addHandler(handler)
+    else:
+        handler = logging.StreamHandler()
+        handler.setLevel(logging.WARNING)
+        logger.addHandler(handler)
 
     if logfile:
         handler = logging.FileHandler(logfile)


### PR DESCRIPTION
Having added a logfile handler removed the default handler implementation. The issue cannot be seen when using `-v` because a console handler is added. But when running without verbose, there is no handler to log to stdout.