### PR TITLE
prepare-node: Error out if script is run as root

### DIFF
--- a/sunbeam-python/sunbeam/commands/prepare_node.py
+++ b/sunbeam-python/sunbeam/commands/prepare_node.py
@@ -32,6 +32,14 @@ PREPARE_NODE_TEMPLATE = f"""#!/bin/bash
 # please review carefully before execution.
 USER=$(whoami)
 
+if [ $(id -u) -eq 0 -o "$USER" = root ]; then
+    cat << EOF
+ERROR: Node Preparation script for OpenStack Sunbeam must be executed by
+       non-root user with sudo permissions.
+EOF
+    exit 1
+fi
+
 # Check if user has passwordless sudo permissions and setup if need be
 SUDO_ASKPASS=/bin/false sudo -A whoami &> /dev/null &&
 sudo grep -r $USER /etc/{{sudoers,sudoers.d}} | grep NOPASSWD:ALL &> /dev/null || {{


### PR DESCRIPTION
Following the instractions for how to deploy Sunbeam will fail if the prepare-node-script is run as root.  Let's take that fact into account and check/bail on this condition.