### PR TITLE
Disable terraform upgrade and security checks

### DIFF
--- a/sunbeam-python/sunbeam/commands/terraform.py
+++ b/sunbeam-python/sunbeam/commands/terraform.py
@@ -47,6 +47,7 @@ terraform {
 """
 
 terraform_rc_template = """
+disable_checkpoint = true
 provider_installation {
   filesystem_mirror {
     path    = "$snap_path/usr/share/terraform-providers"


### PR DESCRIPTION
Disable terraform upgrade and security bulletin checks that require reaching out to HashiCorp-provided network services since all of the terraform providers that are required are shipped as part of the snap

https://developer.hashicorp.com/terraform/cli/config/config-file#disable_checkpoint

Closes-Bug: #2024312