### PR TITLE
Add step to wait for vault reachability in unseal command

### DIFF
--- a/sunbeam-python/sunbeam/plugins/vault/plugin.py
+++ b/sunbeam-python/sunbeam/plugins/vault/plugin.py
@@ -469,6 +469,7 @@ class VaultPlugin(EnableDisablePlugin):
         data_location = self.snap.paths.user_data
         jhelper = JujuHelper(data_location)
         plan = [
+            WaitVaultRouteableStep(jhelper),
             UnsealVaultStep(self, jhelper),
             AuthoriseVaultStep(self, jhelper),
         ]


### PR DESCRIPTION
After a refresh of the charm, there's a time for the vault charm to be reachable. Adding a step to wait for the reachability.

This is a developer QOL improvement, since users are not expected to refresh the charms themselves.