### PR TITLE
Add missing offers for cos plugin based on the upstream COS repository

### DIFF
--- a/sunbeam-python/sunbeam/plugins/cos/etc/deploy-cos/main.tf
+++ b/sunbeam-python/sunbeam/plugins/cos/etc/deploy-cos/main.tf
@@ -438,6 +438,13 @@ resource "juju_offer" "prometheus-metrics-offer" {
   endpoint         = "metrics-endpoint"
 }
 
+# juju offer prometheus:receive-remote-write
+resource "juju_offer" "prometheus-receive-remote-write-offer" {
+  model            = juju_model.cos.name
+  application_name = juju_application.prometheus.name
+  endpoint         = "receive-remote-write"
+}
+
 # juju offer loki:logging
 resource "juju_offer" "loki-logging-offer" {
   model            = juju_model.cos.name
@@ -450,4 +457,11 @@ resource "juju_offer" "grafana-dashboard-offer" {
   model            = juju_model.cos.name
   application_name = juju_application.grafana.name
   endpoint         = "grafana-dashboard"
+}
+
+# juju offer alertmanager:karma-dashboard
+resource "juju_offer" "alertmanager-karma-dashboard-offer" {
+  model            = juju_model.cos.name
+  application_name = juju_application.alertmanager.name
+  endpoint         = "karma-dashboard"
 }

--- a/sunbeam-python/sunbeam/plugins/cos/etc/deploy-cos/outputs.tf
+++ b/sunbeam-python/sunbeam/plugins/cos/etc/deploy-cos/outputs.tf
@@ -20,6 +20,11 @@ output "prometheus-metrics-offer-url" {
   value       = juju_offer.prometheus-metrics-offer.url
 }
 
+output "prometheus-receive-remote-write-offer-url" {
+  description = "URL of the prometheus receive remote write endpoint offer"
+  value       = juju_offer.prometheus-receive-remote-write-offer.url
+}
+
 output "loki-logging-offer-url" {
   description = "URL of the loki logging offer"
   value       = juju_offer.loki-logging-offer.url
@@ -28,4 +33,9 @@ output "loki-logging-offer-url" {
 output "grafana-dashboard-offer-url" {
   description = "URL of the grafana dashboard offer"
   value       = juju_offer.grafana-dashboard-offer.url
+}
+
+output "alertmanager-karma-dashboard-offer-url" {
+  description = "URL of the alertmanager karma dashboard endpoint offer"
+  value       = juju_offer.alertmanager-karma-dashboard-offer.url
 }


### PR DESCRIPTION
Some offers in the COS plugin is missing when comparing to the upstream repository [1]. This patch adds those missing offers.

[1] https://github.com/canonical/cos-lite-bundle/blob/main/overlays/offers-overlay.yaml