### PR TITLE
Disable serialize pulls

### DIFF
--- a/cloud/etc/deploy-microk8s/main.tf
+++ b/cloud/etc/deploy-microk8s/main.tf
@@ -43,8 +43,9 @@ resource "juju_application" "microk8s" {
   }
 
   config = {
-    channel              = var.microk8s_channel
-    addons               = join(" ", [for key, value in var.addons : "${key}:${value}"])
-    disable_cert_reissue = true
+    channel                       = var.microk8s_channel
+    addons                        = join(" ", [for key, value in var.addons : "${key}:${value}"])
+    disable_cert_reissue          = true
+    kubelet_serialize_image_pulls = false
   }
 }


### PR DESCRIPTION
Disabling serialize pulls allows enabling parrallel downloads for oci images, accelerating a deployment.