### PR TITLE
Fix regression from PR #194.

### DIFF
--- a/sunbeam-python/sunbeam/plugins/cos/etc/deploy-cos/main.tf
+++ b/sunbeam-python/sunbeam/plugins/cos/etc/deploy-cos/main.tf
@@ -433,6 +433,7 @@ resource "juju_integration" "catalogue-to-alertmanager" {
 
 # juju offer prometheus:metrics-endpoint
 resource "juju_offer" "prometheus-metrics-offer" {
+  name             = "prometheus-scrape"
   model            = juju_model.cos.name
   application_name = juju_application.prometheus.name
   endpoint         = "metrics-endpoint"
@@ -440,6 +441,7 @@ resource "juju_offer" "prometheus-metrics-offer" {
 
 # juju offer prometheus:receive-remote-write
 resource "juju_offer" "prometheus-receive-remote-write-offer" {
+  name             = "prometheus-receive-remote-write"
   model            = juju_model.cos.name
   application_name = juju_application.prometheus.name
   endpoint         = "receive-remote-write"
@@ -447,6 +449,7 @@ resource "juju_offer" "prometheus-receive-remote-write-offer" {
 
 # juju offer loki:logging
 resource "juju_offer" "loki-logging-offer" {
+  name             = "loki-logging"
   model            = juju_model.cos.name
   application_name = juju_application.loki.name
   endpoint         = "logging"
@@ -454,6 +457,7 @@ resource "juju_offer" "loki-logging-offer" {
 
 # juju offer grafana:dashboard
 resource "juju_offer" "grafana-dashboard-offer" {
+  name             = "grafana-dashboards"
   model            = juju_model.cos.name
   application_name = juju_application.grafana.name
   endpoint         = "grafana-dashboard"
@@ -461,6 +465,7 @@ resource "juju_offer" "grafana-dashboard-offer" {
 
 # juju offer alertmanager:karma-dashboard
 resource "juju_offer" "alertmanager-karma-dashboard-offer" {
+  name             = "alertmanager-karma-dashboard"
   model            = juju_model.cos.name
   application_name = juju_application.alertmanager.name
   endpoint         = "karma-dashboard"


### PR DESCRIPTION
When "name" is not defined in the offer, the "application_name" will be used. This will cause a problem when an application provides more than one "offer" because they will be using the same offer "name" (which is "application_name"), and it's not allowed in Juju.

Error output: `sunbeam enable cos`
```shell
Error: cannot add application offer "prometheus": application offer already exists

  with juju_offer.prometheus-metrics-offer,
  on main.tf line 435, in resource "juju_offer" "prometheus-metrics-offer":
 435: resource "juju_offer" "prometheus-metrics-offer" {


Error deploying COS
Traceback (most recent call last):
  File "/snap/openstack/243/lib/python3.10/site-packages/sunbeam/commands/terraform.py", line 200, in apply
    process = subprocess.run(
  File "/usr/lib/python3.10/subprocess.py", line 524, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['/snap/openstack/243/bin/terraform', 'apply', '-auto-approve', '-no-color']' returned non-zero exit status 1.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/snap/openstack/243/lib/python3.10/site-packages/sunbeam/plugins/cos/plugin.py", line 98, in run
    self.tfhelper.apply()
  File "/snap/openstack/243/lib/python3.10/site-packages/sunbeam/commands/terraform.py", line 214, in apply
    raise TerraformException(str(e))
sunbeam.commands.terraform.TerraformException: Command '['/snap/openstack/243/bin/terraform', 'apply', '-auto-approve', '-no-color']' returned non-zero exit status 1.
Error: Command '['/snap/openstack/243/bin/terraform', 'apply', '-auto-approve', '-no-color']' returned non-zero exit status 1.
```



The offer names are based on [cos-lite-bundle](https://github.com/canonical/cos-lite-bundle/blob/main/overlays/offers-overlay.yaml), I am open to more sensible naming suggestions.