### PR TITLE
Use Juju 3.1

### DIFF
--- a/sunbeam-python/sunbeam/commands/prepare_node.py
+++ b/sunbeam-python/sunbeam/commands/prepare_node.py
@@ -19,7 +19,7 @@ from rich.console import Console
 console = Console()
 
 
-JUJU_CHANNEL = "3.2/stable"
+JUJU_CHANNEL = "3.1/stable"
 SUPPORTED_RELEASE = "jammy"
 
 PREPARE_NODE_TEMPLATE = f"""#!/bin/bash


### PR DESCRIPTION
Use juju 3.1 as CMR fixes should have been backported and 3.1 has a longer life than 3.2