### PR TITLE
Pin agent version to avoid pebble bug

### DIFF
--- a/sunbeam-python/sunbeam/commands/juju.py
+++ b/sunbeam-python/sunbeam/commands/juju.py
@@ -284,6 +284,7 @@ class BootstrapJujuStep(BaseStep, JujuStepHelper):
                 "bootstrap",
                 self.cloud,
                 self.controller,
+                "--agent-version=3.2.0",
             ]
             LOG.debug(f'Running command {" ".join(cmd)}')
             process = subprocess.run(cmd, capture_output=True, text=True, check=True)


### PR DESCRIPTION
Pin agent version to avoid pebble bug *1 introduced in the latest juju 3.2.2 release.

*1 https://github.com/canonical/pebble/issues/260